### PR TITLE
refactor: centralize master server instance

### DIFF
--- a/server/src/masterServer.ts
+++ b/server/src/masterServer.ts
@@ -1,0 +1,16 @@
+const MatchmakingService = require('../matchmaking/MatchmakingService');
+const FightManager = require('../combat/FightManager');
+
+class MasterServer {
+  matchmaking: any;
+  fightManager: any;
+
+  constructor() {
+    this.matchmaking = new MatchmakingService();
+    this.fightManager = new FightManager();
+  }
+}
+
+const masterServer = new MasterServer();
+
+export default masterServer;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -9,6 +9,9 @@ import fightsRouter from './routes/fights';
 import fightsTestRouter from './routes/fights-test';
 import fightsOfficialRouter from './routes/fights-official';
 import matchmakingRouter from './routes/matchmaking';
+import masterServer from './masterServer';
+
+export { masterServer };
 
 const app = express();
 app.use(cors());


### PR DESCRIPTION
## Summary
- expose a shared `masterServer` hosting the matchmaking service and fight manager
- export `masterServer` from the API server
- use the shared `masterServer` in matchmaking routes instead of new service instances

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad503a3f208320b22d8d26fa73185a