### PR TITLE
Integrate MasterServer for matchmaking

### DIFF
--- a/server/src/routes/matchmaking.ts
+++ b/server/src/routes/matchmaking.ts
@@ -3,213 +3,212 @@ import { z } from 'zod';
 import prisma from '../lib/prisma';
 import { requireAuth, AuthRequest } from '../middleware/auth';
 
-// Import matchmaking service
-const MatchmakingService = require('../../matchmaking/MatchmakingService');
 const FightManager = require('../../combat/FightManager');
 
-const router = Router();
-const matchmakingService = new MatchmakingService();
-const fightManager = new FightManager();
+export default function matchmakingRouter(masterServer: any) {
+  const router = Router();
+  const matchmakingService = masterServer.matchmaking;
+  const fightManager = new FightManager();
 
-// Schema validation
-const JoinQueueSchema = z.object({
-  bruteId: z.string().uuid(),
-  preferences: z.object({
-    searchRange: z.number().optional(),
-    preferredLevel: z.number().optional()
-  }).optional()
-});
+  const JoinQueueSchema = z.object({
+    bruteId: z.string().uuid(),
+    preferences: z.object({
+      searchRange: z.number().optional(),
+      preferredLevel: z.number().optional()
+    }).optional()
+  });
 
-/**
- * Join matchmaking queue
- */
-router.post('/queue/join', requireAuth, async (req: AuthRequest, res) => {
-  const parse = JoinQueueSchema.safeParse(req.body);
-  if (!parse.success) {
-    return res.status(400).json({ error: 'Invalid body', details: parse.error.flatten() });
-  }
+  /**
+   * Join matchmaking queue
+   */
+  router.post('/queue/join', requireAuth, async (req: AuthRequest, res) => {
+    const parse = JoinQueueSchema.safeParse(req.body);
+    if (!parse.success) {
+      return res.status(400).json({ error: 'Invalid body', details: parse.error.flatten() });
+    }
 
-  const { bruteId, preferences } = parse.data;
-  const userId = req.user?.id;
+    const { bruteId, preferences } = parse.data;
+    const userId = req.user?.id;
 
-  if (!userId) {
-    return res.status(401).json({ error: 'Authentication required' });
-  }
+    if (!userId) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
 
-  try {
-    // Get brute data from database
-    const brute = await prisma.shacker.findUnique({ 
-      where: { id: bruteId },
-      include: {
-        owner: true // Include user data
+    try {
+      // Get brute data from database
+      const brute = await prisma.shacker.findUnique({
+        where: { id: bruteId },
+        include: {
+          owner: true // Include user data
+        }
+      });
+
+      if (!brute) {
+        return res.status(404).json({ error: 'Brute not found' });
       }
+
+      // Verify ownership
+      if (brute.ownerId !== userId) {
+        return res.status(403).json({ error: 'Not your brute' });
+      }
+
+      // Join queue
+      const queueStatus = matchmakingService.joinQueue(userId, brute, preferences);
+
+      // Try to find immediate match
+      const match = matchmakingService.findMatch(userId);
+
+      if (match) {
+        // Match found! Generate fight immediately
+        const fightResult = fightManager.generateFight(
+          match.player1.bruteData,
+          match.player2.bruteData
+        );
+
+        // Complete the match
+        const winnerId = fightResult.winner === match.player1.bruteData.name
+          ? match.player1.userId
+          : match.player2.userId;
+        const loserId = winnerId === match.player1.userId
+          ? match.player2.userId
+          : match.player1.userId;
+
+        matchmakingService.completeMatch(match.matchId, winnerId, loserId, fightResult);
+
+        return res.json({
+          matchFound: true,
+          match,
+          fight: fightResult
+        });
+      }
+
+      return res.json({
+        matchFound: false,
+        queueStatus,
+        message: 'Searching for opponent...'
+      });
+
+    } catch (error) {
+      console.error('Matchmaking error:', error);
+      return res.status(500).json({ error: 'Matchmaking failed' });
+    }
+  });
+
+  /**
+   * Leave matchmaking queue
+   */
+  router.post('/queue/leave', requireAuth, async (req: AuthRequest, res) => {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+
+    const removed = matchmakingService.leaveQueue(userId);
+
+    return res.json({
+      success: removed,
+      message: removed ? 'Left queue successfully' : 'Not in queue'
     });
+  });
 
-    if (!brute) {
-      return res.status(404).json({ error: 'Brute not found' });
+  /**
+   * Get queue status
+   */
+  router.get('/queue/status', requireAuth, async (req: AuthRequest, res) => {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ error: 'Authentication required' });
     }
 
-    // Verify ownership
-    if (brute.ownerId !== userId) {
-      return res.status(403).json({ error: 'Not your brute' });
-    }
+    const status = matchmakingService.getQueueStatus();
+    const playerInQueue = matchmakingService.playerQueue.has(userId);
 
-    // Join queue
-    const queueStatus = matchmakingService.joinQueue(userId, brute, preferences);
+    return res.json({
+      ...status,
+      playerInQueue,
+      userRating: matchmakingService.getPlayerRating(userId)
+    });
+  });
 
-    // Try to find immediate match
-    const match = matchmakingService.findMatch(userId);
-    
-    if (match) {
-      // Match found! Generate fight immediately
+  /**
+   * Force match between two players (for testing)
+   */
+  router.post('/match/force', requireAuth, async (req: AuthRequest, res) => {
+    const { player1Id, player2Id } = req.body;
+
+    try {
+      const match = matchmakingService.forceMatch(player1Id, player2Id);
+
+      // Generate fight immediately
       const fightResult = fightManager.generateFight(
-        match.player1.bruteData, 
+        match.player1.bruteData,
         match.player2.bruteData
       );
 
-      // Complete the match
-      const winnerId = fightResult.winner === match.player1.bruteData.name 
-        ? match.player1.userId 
-        : match.player2.userId;
-      const loserId = winnerId === match.player1.userId 
-        ? match.player2.userId 
-        : match.player1.userId;
-
-      matchmakingService.completeMatch(match.matchId, winnerId, loserId, fightResult);
-
       return res.json({
-        matchFound: true,
         match,
         fight: fightResult
       });
+
+    } catch (error: any) {
+      return res.status(400).json({ error: error.message });
+    }
+  });
+
+  /**
+   * Get player statistics
+   */
+  router.get('/stats/:userId', requireAuth, async (req: AuthRequest, res) => {
+    const { userId } = req.params;
+
+    const stats = matchmakingService.playerStats.get(userId) || {
+      wins: 0,
+      losses: 0,
+      rating: 1000
+    };
+
+    const winRate = stats.wins + stats.losses > 0
+      ? (stats.wins / (stats.wins + stats.losses) * 100).toFixed(1)
+      : '0.0';
+
+    return res.json({
+      ...stats,
+      winRate: `${winRate}%`,
+      totalFights: stats.wins + stats.losses
+    });
+  });
+
+  /**
+   * Get match history
+   */
+  router.get('/history', requireAuth, async (req: AuthRequest, res) => {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ error: 'Authentication required' });
     }
 
-    return res.json({
-      matchFound: false,
-      queueStatus,
-      message: 'Searching for opponent...'
-    });
+    const userMatches = matchmakingService.matchHistory
+      .filter(match =>
+        match.player1.userId === userId || match.player2.userId === userId
+      )
+      .slice(-20) // Last 20 matches
+      .map(match => ({
+        matchId: match.matchId,
+        opponent: match.player1.userId === userId
+          ? match.player2.bruteData.name
+          : match.player1.bruteData.name,
+        result: match.winnerId === userId ? 'win' : 'loss',
+        duration: match.duration,
+        completedAt: match.completedAt
+      }));
 
-  } catch (error) {
-    console.error('Matchmaking error:', error);
-    return res.status(500).json({ error: 'Matchmaking failed' });
-  }
-});
-
-/**
- * Leave matchmaking queue
- */
-router.post('/queue/leave', requireAuth, async (req: AuthRequest, res) => {
-  const userId = req.user?.id;
-  if (!userId) {
-    return res.status(401).json({ error: 'Authentication required' });
-  }
-
-  const removed = matchmakingService.leaveQueue(userId);
-  
-  return res.json({
-    success: removed,
-    message: removed ? 'Left queue successfully' : 'Not in queue'
+    return res.json({ matches: userMatches });
   });
-});
 
-/**
- * Get queue status
- */
-router.get('/queue/status', requireAuth, async (req: AuthRequest, res) => {
-  const userId = req.user?.id;
-  if (!userId) {
-    return res.status(401).json({ error: 'Authentication required' });
-  }
+  // Cleanup task - run periodically
+  setInterval(() => {
+    matchmakingService.cleanup();
+  }, 60000); // Every minute
 
-  const status = matchmakingService.getQueueStatus();
-  const playerInQueue = matchmakingService.playerQueue.has(userId);
-
-  return res.json({
-    ...status,
-    playerInQueue,
-    userRating: matchmakingService.getPlayerRating(userId)
-  });
-});
-
-/**
- * Force match between two players (for testing)
- */
-router.post('/match/force', requireAuth, async (req: AuthRequest, res) => {
-  const { player1Id, player2Id } = req.body;
-  
-  try {
-    const match = matchmakingService.forceMatch(player1Id, player2Id);
-    
-    // Generate fight immediately
-    const fightResult = fightManager.generateFight(
-      match.player1.bruteData, 
-      match.player2.bruteData
-    );
-
-    return res.json({
-      match,
-      fight: fightResult
-    });
-
-  } catch (error) {
-    return res.status(400).json({ error: error.message });
-  }
-});
-
-/**
- * Get player statistics
- */
-router.get('/stats/:userId', requireAuth, async (req: AuthRequest, res) => {
-  const { userId } = req.params;
-  
-  const stats = matchmakingService.playerStats.get(userId) || {
-    wins: 0,
-    losses: 0,
-    rating: 1000
-  };
-
-  const winRate = stats.wins + stats.losses > 0 
-    ? (stats.wins / (stats.wins + stats.losses) * 100).toFixed(1)
-    : '0.0';
-
-  return res.json({
-    ...stats,
-    winRate: `${winRate}%`,
-    totalFights: stats.wins + stats.losses
-  });
-});
-
-/**
- * Get match history
- */
-router.get('/history', requireAuth, async (req: AuthRequest, res) => {
-  const userId = req.user?.id;
-  if (!userId) {
-    return res.status(401).json({ error: 'Authentication required' });
-  }
-
-  const userMatches = matchmakingService.matchHistory
-    .filter(match => 
-      match.player1.userId === userId || match.player2.userId === userId
-    )
-    .slice(-20) // Last 20 matches
-    .map(match => ({
-      matchId: match.matchId,
-      opponent: match.player1.userId === userId 
-        ? match.player2.bruteData.name 
-        : match.player1.bruteData.name,
-      result: match.winnerId === userId ? 'win' : 'loss',
-      duration: match.duration,
-      completedAt: match.completedAt
-    }));
-
-  return res.json({ matches: userMatches });
-});
-
-// Cleanup task - run periodically
-setInterval(() => {
-  matchmakingService.cleanup();
-}, 60000); // Every minute
-
-export default router;
+  return router;
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -41,7 +41,6 @@ app.use('/api/shackers', shackersRouter);
 app.use('/api/fights', fightsTestRouter); // Use test router for now
 app.use('/api/fights', fightsOfficialRouter); // OFFICIAL LABRUTE ENGINE
 // app.use('/api/fights', fightsRouter); // Original with DB
-app.use('/api/matchmaking', matchmakingRouter);
 
 // Serve static public/ from project root
 const rootDir = path.resolve(__dirname, '..', '..');
@@ -52,6 +51,11 @@ app.get('/', (_req, res) => {
 });
 
 const PORT = parseInt(process.env.PORT || '4000', 10);
-app.listen(PORT, () => {
+const httpServer = app.listen(PORT, () => {
   console.log(`API listening on http://localhost:${PORT}`);
 });
+
+const MasterServer = require('../master/MasterServer');
+const masterServer = new MasterServer(httpServer);
+
+app.use('/api/matchmaking', matchmakingRouter(masterServer));


### PR DESCRIPTION
## Summary
- Capture HTTP server from `app.listen` and spin up MasterServer
- Route matchmaking requests through `masterServer.matchmaking`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4e562d4c8320ac90bd6313d0f254