### PR TITLE
Add root npm test script for server tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ An active subscription to Phaser Editor is required to load and use this templat
 | `npm install`   | Install project dependencies |
 | `npm start`     | Launch a development web server |
 | `npm run build` | Create a production build in the `dist` folder |
+| `npm test`     | Run server tests |
+
+## Testing
+
+Contributors can run the server test suite from the project root using:
+
+```bash
+npm test
+```
+
+This command delegates to the tests defined in the `server` directory.
 
 ## Writing Code
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "start": "vite --config vite/config.dev.mjs",
         "dev": "vite --config vite/config.dev.mjs",
         "build": "vite build --config vite/config.prod.mjs && phaser-asset-pack-hashing -j -r dist",
+        "test": "npm --prefix server test",
         "test:combat": "node scripts/runCombatTest.mjs",
         "test:combat:snap": "node scripts/runCombatTest.mjs --snapshot --seed=42",
         "test:combat:debug": "node scripts/runCombatTest.mjs --debug --seed=42",


### PR DESCRIPTION
## Summary
- add root `npm test` script that forwards to server tests
- document running tests for contributors

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4e4d2fcc8320a3190bd6fbe5c4f7