### PR TITLE
Replace owner references with user in matchmaking route

### DIFF
--- a/server/src/routes/matchmaking.ts
+++ b/server/src/routes/matchmaking.ts
@@ -38,10 +38,10 @@ router.post('/queue/join', requireAuth, async (req: AuthRequest, res) => {
 
   try {
     // Get brute data from database
-    const brute = await prisma.shacker.findUnique({ 
+    const brute = await prisma.shacker.findUnique({
       where: { id: bruteId },
       include: {
-        owner: true // Include user data
+        user: true
       }
     });
 
@@ -50,7 +50,7 @@ router.post('/queue/join', requireAuth, async (req: AuthRequest, res) => {
     }
 
     // Verify ownership
-    if (brute.ownerId !== userId) {
+    if (brute.userId !== userId) {
       return res.status(403).json({ error: 'Not your brute' });
     }
 


### PR DESCRIPTION
## Summary
- update matchmaking route to include related user and check userId instead of ownerId

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad4e4a02788320a35d065021fee1cf