### PR TITLE
chore: run server tests from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
         "test:combat:debug": "node scripts/runCombatTest.mjs --debug --seed=42",
         "test:combat:debug:pets": "node scripts/runCombatTest.mjs --debug --pets --petA=panther --petB=dog1 --seed=42 --snapshot --output=.snapshots/fights/seed-42-debug-pets.json",
         "test:combat:exact": "node scripts/runCombatTest.mjs --formulas=exact",
-        "test:combat:exact:debug": "node scripts/runCombatTest.mjs --formulas=exact --debug --seed=42"
+        "test:combat:exact:debug": "node scripts/runCombatTest.mjs --formulas=exact --debug --seed=42",
+        "test": "npm --prefix server test"
     },
     "devDependencies": {
         "phaser-asset-pack-hashing": "^1.0.6",

--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,7 @@
     "db:migrate": "prisma migrate dev --name init",
     "db:deploy": "prisma migrate deploy",
     "db:studio": "prisma studio",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test tests"
   },
   "keywords": [],
   "author": "",

--- a/server/tests/sanity.test.js
+++ b/server/tests/sanity.test.js
@@ -1,0 +1,6 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+test('simple addition', (t) => {
+  assert.strictEqual(1 + 2, 3);
+});


### PR DESCRIPTION
## Summary
- add simple sanity test in server and configure server's `test` script
- run server tests from root `npm test`

## Testing
- `npm --prefix server test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad4e2f0dc8832091ddb65b014ac33d