### PR TITLE
Use user relation in matchmaking lookup

### DIFF
--- a/server/src/routes/matchmaking.ts
+++ b/server/src/routes/matchmaking.ts
@@ -38,10 +38,10 @@ router.post('/queue/join', requireAuth, async (req: AuthRequest, res) => {
 
   try {
     // Get brute data from database
-    const brute = await prisma.shacker.findUnique({ 
+    const brute = await prisma.shacker.findUnique({
       where: { id: bruteId },
       include: {
-        owner: true // Include user data
+        user: true // Include user data
       }
     });
 


### PR DESCRIPTION
## Summary
- query user relation when fetching a brute for matchmaking

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad4e2d2cf883208af446ac6876287a