### PR TITLE
Add root test script and document test invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,15 @@ An active subscription to Phaser Editor is required to load and use this templat
 | `npm install`   | Install project dependencies |
 | `npm start`     | Launch a development web server |
 | `npm run build` | Create a production build in the `dist` folder |
+| `npm test`      | Run the server tests from the project root |
 
 ## Writing Code
 
 After cloning the repo, run `npm install` from your project directory.
 
 To start the local development server use `npm run dev`.
+
+To run the test suite, execute `npm test` from the project root. This forwards the command to the server package.
 
 ## Deploying to Production
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "start": "vite --config vite/config.dev.mjs",
         "dev": "vite --config vite/config.dev.mjs",
         "build": "vite build --config vite/config.prod.mjs && phaser-asset-pack-hashing -j -r dist",
+        "test": "npm --prefix server test",
         "test:combat": "node scripts/runCombatTest.mjs",
         "test:combat:snap": "node scripts/runCombatTest.mjs --snapshot --seed=42",
         "test:combat:debug": "node scripts/runCombatTest.mjs --debug --seed=42",


### PR DESCRIPTION
## Summary
- add root `npm test` script to run server tests
- document how to invoke tests from repository root

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4e2d25a8832085c96d8333028c4a