### PR TITLE
refactor: centralize matchmaking with master server

### DIFF
--- a/server/src/masterServer.ts
+++ b/server/src/masterServer.ts
@@ -1,0 +1,15 @@
+import MatchmakingService from '../matchmaking/MatchmakingService';
+import FightManager from '../combat/FightManager';
+
+class MasterServer {
+  public matchmaking: MatchmakingService;
+  public fightManager: FightManager;
+
+  constructor() {
+    this.matchmaking = new MatchmakingService();
+    this.fightManager = new FightManager();
+  }
+}
+
+const masterServer = new MasterServer();
+export default masterServer;

--- a/server/src/routes/matchmaking.ts
+++ b/server/src/routes/matchmaking.ts
@@ -2,14 +2,11 @@ import { Router } from 'express';
 import { z } from 'zod';
 import prisma from '../lib/prisma';
 import { requireAuth, AuthRequest } from '../middleware/auth';
-
-// Import matchmaking service
-const MatchmakingService = require('../../matchmaking/MatchmakingService');
-const FightManager = require('../../combat/FightManager');
+import masterServer from '../masterServer';
 
 const router = Router();
-const matchmakingService = new MatchmakingService();
-const fightManager = new FightManager();
+const matchmakingService = masterServer.matchmaking;
+const fightManager = masterServer.fightManager;
 
 // Schema validation
 const JoinQueueSchema = z.object({

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -9,6 +9,7 @@ import fightsRouter from './routes/fights';
 import fightsTestRouter from './routes/fights-test';
 import fightsOfficialRouter from './routes/fights-official';
 import matchmakingRouter from './routes/matchmaking';
+import masterServer from './masterServer';
 
 const app = express();
 app.use(cors());
@@ -55,3 +56,5 @@ const PORT = parseInt(process.env.PORT || '4000', 10);
 app.listen(PORT, () => {
   console.log(`API listening on http://localhost:${PORT}`);
 });
+
+export { masterServer };


### PR DESCRIPTION
## Summary
- add `masterServer` singleton hosting matchmaking and fight manager
- refactor matchmaking route to use shared master server
- export master server instance from main server entry

## Testing
- `npm run test:combat`


------
https://chatgpt.com/codex/tasks/task_e_68ad129280b8832092ae04f0d6553a7c