### PR TITLE
Add root test command and contributor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ An active subscription to Phaser Editor is required to load and use this templat
 | `npm install`   | Install project dependencies |
 | `npm start`     | Launch a development web server |
 | `npm run build` | Create a production build in the `dist` folder |
+| `npm test`      | Run server tests from the project root |
+
+## Running Tests
+
+Run the server test suite from the project root:
+
+```sh
+npm test
+```
 
 ## Writing Code
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "start": "vite --config vite/config.dev.mjs",
         "dev": "vite --config vite/config.dev.mjs",
         "build": "vite build --config vite/config.prod.mjs && phaser-asset-pack-hashing -j -r dist",
+        "test": "npm --prefix server test",
         "test:combat": "node scripts/runCombatTest.mjs",
         "test:combat:snap": "node scripts/runCombatTest.mjs --snapshot --seed=42",
         "test:combat:debug": "node scripts/runCombatTest.mjs --debug --seed=42",


### PR DESCRIPTION
## Summary
- add npm test script at repo root to run server tests
- document running tests with `npm test`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1291635083209043e5c4cc3bc770