### PR TITLE
feat: use official hit formulas with deterministic RNG

### DIFF
--- a/server/engine/labrute-official/attemptHit.js
+++ b/server/engine/labrute-official/attemptHit.js
@@ -1,0 +1,43 @@
+/**
+ * OFFICIAL LABRUTE HIT RESOLUTION
+ * Implements accuracy, evasion, block and counter formulas
+ */
+
+const { getFighterStat } = require('./getFighterStat');
+
+/**
+ * Attempt to hit an opponent using official formulas
+ * @param {Object} fighter - attacking fighter
+ * @param {Object} opponent - defending fighter
+ * @returns {Object} result with flags: hit, evaded, blocked, counter
+ */
+function attemptHit(fighter, opponent) {
+  // Accuracy check
+  const accuracy = getFighterStat(fighter, 'ACCURACY');
+  if (Math.random() >= accuracy) {
+    return { hit: false };
+  }
+
+  // Evasion check
+  const evadeChance = getFighterStat(opponent, 'EVASION');
+  if (Math.random() < evadeChance) {
+    return { hit: false, evaded: true };
+  }
+
+  // Block check (official cap at 40%)
+  const blockChance = Math.min(getFighterStat(opponent, 'BLOCK'), 0.4);
+  if (Math.random() < blockChance) {
+    return { hit: false, blocked: true };
+  }
+
+  // Counter check
+  const counterChance = getFighterStat(opponent, 'COUNTER');
+  if (counterChance && Math.random() < counterChance) {
+    return { hit: false, counter: true };
+  }
+
+  // Successful hit
+  return { hit: true };
+}
+
+module.exports = { attemptHit };

--- a/server/engine/labrute-official/getDamage.js
+++ b/server/engine/labrute-official/getDamage.js
@@ -8,6 +8,32 @@ const { SkillName, WeaponName } = require('./constants');
 const { getFighterStat } = require('./getFighterStat');
 const { SkillDamageModifiers } = require('./skillModifiers');
 
+// Helper to check if a fighter has a skill (supports string or object format)
+function hasSkill(fighter, skill) {
+  if (!fighter || !fighter.skills) {
+    return false;
+  }
+  return fighter.skills.some((sk) => {
+    if (typeof sk === 'string') {
+      return sk === skill;
+    }
+    return sk.name === skill;
+  });
+}
+
+// Helper to check active skills (which may also be strings)
+function hasActiveSkill(fighter, skill) {
+  if (!fighter || !fighter.activeSkills) {
+    return false;
+  }
+  return fighter.activeSkills.some((sk) => {
+    if (typeof sk === 'string') {
+      return sk === skill;
+    }
+    return sk.name === skill;
+  });
+}
+
 /**
  * Calculate damage dealt by a fighter to an opponent
  * @param {Object} fighter - The attacking fighter
@@ -24,12 +50,12 @@ const getDamage = (fighter, opponent, thrown = null) => {
   let skillsMultiplier = 1;
 
   // Check if Piledriver (hammer skill) is active
-  const piledriver = fighter.activeSkills.find((sk) => sk.name === SkillName.hammer);
+  const piledriver = hasActiveSkill(fighter, SkillName.hammer);
 
   // Apply fighter skill damage modifiers
   for (const modifier of SkillDamageModifiers) {
     // Skip if fighter doesn't have the skill
-    if (!fighter.skills.find((sk) => sk.name === modifier.skill)) {
+    if (!hasSkill(fighter, modifier.skill)) {
       continue;
     }
 
@@ -70,7 +96,7 @@ const getDamage = (fighter, opponent, thrown = null) => {
   // Apply opponent skill damage modifiers (damage reduction)
   for (const modifier of SkillDamageModifiers) {
     // Skip if opponent doesn't have the skill
-    if (!opponent.skills.find((sk) => sk.name === modifier.skill)) {
+    if (!hasSkill(opponent, modifier.skill)) {
       continue;
     }
 
@@ -102,7 +128,7 @@ const getDamage = (fighter, opponent, thrown = null) => {
   }
 
   // x2 damage if fierceBrute skill is active
-  if (fighter.activeSkills.find((sk) => sk.name === 'fierceBrute')) {
+  if (hasActiveSkill(fighter, 'fierceBrute')) {
     skillsMultiplier *= 2;
   }
 

--- a/server/engine/labrute-official/seedRandom.js
+++ b/server/engine/labrute-official/seedRandom.js
@@ -1,0 +1,19 @@
+/**
+ * Simple deterministic RNG based on a linear congruential generator
+ * Returns a function compatible with Math.random
+ */
+function seedRandom(seed) {
+  // Convert non-number seeds to a numeric value
+  if (typeof seed !== 'number') {
+    seed = String(seed)
+      .split('')
+      .reduce((acc, ch) => acc + ch.charCodeAt(0), 0);
+  }
+  let value = seed % 233280;
+  return function() {
+    value = (value * 9301 + 49297) % 233280;
+    return value / 233280;
+  };
+}
+
+module.exports = { seedRandom };

--- a/server/src/engine/OfficialFightGenerator.js
+++ b/server/src/engine/OfficialFightGenerator.js
@@ -5,79 +5,91 @@
  */
 
 const { getDamage } = require('../../../server/engine/labrute-official/getDamage');
-const { weapons, getWeapon } = require('../../../server/engine/labrute-official/weapons');
+const { getWeapon } = require('../../../server/engine/labrute-official/weapons');
+const { attemptHit } = require('../../../server/engine/labrute-official/attemptHit');
+const { seedRandom } = require('../../../server/engine/labrute-official/seedRandom');
 
 /**
  * Generate a complete fight using official LaBrute rules
  */
-async function generateOfficialFight(fighter1Data, fighter2Data) {
+async function generateOfficialFight(fighter1Data, fighter2Data, seed = Date.now()) {
   console.log('🎯 Generating fight with OFFICIAL LaBrute engine');
+
+  // Seed RNG for deterministic fights
+  const originalRandom = Math.random;
+  Math.random = seedRandom(seed);
   
-  // Initialize fighters with official stats
-  const fighters = [
-    createOfficialFighter(fighter1Data, 0),
-    createOfficialFighter(fighter2Data, 1),
-  ];
-  
-  const steps = [];
-  let turn = 0;
-  const maxTurns = 500;
-  
-  // Add arrival steps
-  steps.push({ type: 'arrive', fighter: 0 });
-  steps.push({ type: 'arrive', fighter: 1 });
-  
-  // Main combat loop
-  while (turn < maxTurns) {
-    // Determine turn order based on initiative
-    const turnOrder = determineTurnOrder(fighters);
-    
-    for (const fighterIndex of turnOrder) {
-      const fighter = fighters[fighterIndex];
-      const opponent = fighters[1 - fighterIndex];
-      
-      // Skip if fighter is dead
-      if (fighter.hp <= 0) continue;
-      
-      // Fighter turn
-      const turnSteps = playFighterTurn(fighter, opponent, fighterIndex);
-      steps.push(...turnSteps);
-      
-      // Check for death
-      if (opponent.hp <= 0) {
-        steps.push({ type: 'death', fighter: 1 - fighterIndex });
-        steps.push({ 
-          type: 'end', 
-          winner: fighterIndex,
-          loser: 1 - fighterIndex 
-        });
-        
-        return {
-          steps,
-          fighters,
-          winner: fighter,
-          loser: opponent,
-        };
+  try {
+    // Initialize fighters with official stats
+    const fighters = [
+      createOfficialFighter(fighter1Data, 0),
+      createOfficialFighter(fighter2Data, 1),
+    ];
+
+    const steps = [];
+    let turn = 0;
+    const maxTurns = 500;
+
+    // Add arrival steps
+    steps.push({ type: 'arrive', fighter: 0 });
+    steps.push({ type: 'arrive', fighter: 1 });
+
+    // Main combat loop
+    while (turn < maxTurns) {
+      // Determine turn order based on initiative
+      const turnOrder = determineTurnOrder(fighters);
+
+      for (const fighterIndex of turnOrder) {
+        const fighter = fighters[fighterIndex];
+        const opponent = fighters[1 - fighterIndex];
+
+        // Skip if fighter is dead
+        if (fighter.hp <= 0) continue;
+
+        // Fighter turn
+        const turnSteps = playFighterTurn(fighter, opponent, fighterIndex);
+        steps.push(...turnSteps);
+
+        // Check for death
+        if (opponent.hp <= 0) {
+          steps.push({ type: 'death', fighter: 1 - fighterIndex });
+          steps.push({
+            type: 'end',
+            winner: fighterIndex,
+            loser: 1 - fighterIndex
+          });
+
+          return {
+            steps,
+            fighters,
+            winner: fighter,
+            loser: opponent,
+            seed,
+          };
+        }
       }
+
+      turn++;
     }
-    
-    turn++;
+
+    // Time out - fighter with more HP wins
+    const winner = fighters[0].hp > fighters[1].hp ? 0 : 1;
+    steps.push({
+      type: 'end',
+      winner: winner,
+      loser: 1 - winner
+    });
+
+    return {
+      steps,
+      fighters,
+      winner: fighters[winner],
+      loser: fighters[1 - winner],
+      seed,
+    };
+  } finally {
+    Math.random = originalRandom;
   }
-  
-  // Time out - fighter with more HP wins
-  const winner = fighters[0].hp > fighters[1].hp ? 0 : 1;
-  steps.push({ 
-    type: 'end', 
-    winner: winner,
-    loser: 1 - winner 
-  });
-  
-  return {
-    steps,
-    fighters,
-    winner: fighters[winner],
-    loser: fighters[1 - winner],
-  };
 }
 
 /**
@@ -213,56 +225,56 @@ function playFighterTurn(fighter, opponent, fighterIndex) {
   });
   
   // Attempt to hit
-  const hitResult = attemptHit(fighter, opponent);
-  
-  if (hitResult.hit) {
-    // Calculate damage using official formula
-    const damageResult = getDamage(fighter, opponent);
-    
-    // Apply damage
-    opponent.hp -= damageResult.damage;
-    
-    steps.push({
-      type: 'hit',
-      fighter: fighterIndex,
-      target: 1 - fighterIndex,
-      damage: damageResult.damage,
-      critical: damageResult.criticalHit,
-      weapon: fighter.activeWeapon?.name,
-      targetHP: Math.max(0, opponent.hp),
-    });
-    
-    // Check for counter attack
-    if (opponent.skills.includes('counterAttack') && Math.random() < 0.3) {
-      const counterDamage = Math.floor(damageResult.damage * 0.5);
-      fighter.hp -= counterDamage;
-      
+    const hitResult = attemptHit(fighter, opponent);
+
+    if (hitResult.hit) {
+      // Calculate damage using official formula
+      const damageResult = getDamage(fighter, opponent);
+
+      // Apply damage
+      opponent.hp -= damageResult.damage;
+
       steps.push({
-        type: 'counter',
-        fighter: 1 - fighterIndex,
-        target: fighterIndex,
-        damage: counterDamage,
-        targetHP: Math.max(0, fighter.hp),
+        type: 'hit',
+        fighter: fighterIndex,
+        target: 1 - fighterIndex,
+        damage: damageResult.damage,
+        critical: damageResult.criticalHit,
+        weapon: fighter.activeWeapon?.name,
+        targetHP: Math.max(0, opponent.hp),
       });
-    }
-  } else if (hitResult.evaded) {
-    steps.push({
-      type: 'evade',
-      fighter: 1 - fighterIndex,
-    });
-  } else if (hitResult.blocked) {
-    steps.push({
-      type: 'block',
-      fighter: 1 - fighterIndex,
-      damage: 0,
-    });
-  } else {
-    steps.push({
-      type: 'miss',
-      fighter: fighterIndex,
-      target: 1 - fighterIndex,
-    });
-  }
+      } else if (hitResult.counter) {
+        // Opponent counter-attacks
+        const counterDamage = getDamage(opponent, fighter);
+        fighter.hp -= counterDamage.damage;
+
+        steps.push({
+          type: 'counter',
+          fighter: 1 - fighterIndex,
+          target: fighterIndex,
+          damage: counterDamage.damage,
+          critical: counterDamage.criticalHit,
+          weapon: opponent.activeWeapon?.name,
+          targetHP: Math.max(0, fighter.hp),
+        });
+      } else if (hitResult.evaded) {
+        steps.push({
+          type: 'evade',
+          fighter: 1 - fighterIndex,
+        });
+      } else if (hitResult.blocked) {
+        steps.push({
+          type: 'block',
+          fighter: 1 - fighterIndex,
+          damage: 0,
+        });
+      } else {
+        steps.push({
+          type: 'miss',
+          fighter: fighterIndex,
+          target: 1 - fighterIndex,
+        });
+      }
   
   // Move back
   steps.push({
@@ -271,53 +283,6 @@ function playFighterTurn(fighter, opponent, fighterIndex) {
   });
   
   return steps;
-}
-
-/**
- * Attempt to hit an opponent
- */
-function attemptHit(fighter, opponent) {
-  // Base hit chance
-  let hitChance = 0.5;
-  
-  // Add accuracy from weapon
-  if (fighter.activeWeapon) {
-    hitChance += fighter.activeWeapon.accuracy * 0.3;
-  }
-  
-  // Add agility difference
-  hitChance += (fighter.agility - opponent.agility) * 0.02;
-  
-  // Check for evasion
-  let evadeChance = 0.1;
-  evadeChance += opponent.agility * 0.01;
-  if (opponent.activeWeapon) {
-    evadeChance += opponent.activeWeapon.evasion * 0.2;
-  }
-  
-  // Check for block
-  let blockChance = 0.1;
-  if (opponent.activeWeapon) {
-    blockChance += opponent.activeWeapon.block * 0.3;
-  }
-  if (opponent.skills.includes('block')) {
-    blockChance += 0.2;
-  }
-  
-  // Roll the dice
-  const roll = Math.random();
-  
-  if (roll < evadeChance) {
-    return { hit: false, evaded: true };
-  }
-  if (roll < evadeChance + blockChance) {
-    return { hit: false, blocked: true };
-  }
-  if (roll < hitChance) {
-    return { hit: true };
-  }
-  
-  return { hit: false };
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- add official attemptHit implementation with accuracy, evasion, block, and counter rules
- seed fight generation RNG for deterministic replays
- support string-based skill lists in official damage formula

## Testing
- `npm test` (fails: Missing script "test")
- `npm run test:combat:exact`
- `npm run test:combat`


------
https://chatgpt.com/codex/tasks/task_e_68ad104f07b8832089f18483c8ed762c