### PR TITLE
chore: run server tests from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "start": "vite --config vite/config.dev.mjs",
         "dev": "vite --config vite/config.dev.mjs",
         "build": "vite build --config vite/config.prod.mjs && phaser-asset-pack-hashing -j -r dist",
+        "test": "npm --prefix server test",
         "test:combat": "node scripts/runCombatTest.mjs",
         "test:combat:snap": "node scripts/runCombatTest.mjs --snapshot --seed=42",
         "test:combat:debug": "node scripts/runCombatTest.mjs --debug --seed=42",

--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,7 @@
     "db:migrate": "prisma migrate dev --name init",
     "db:deploy": "prisma migrate deploy",
     "db:studio": "prisma studio",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test-db.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- run server database check as the server's test script
- invoke server test suite from root `npm test`

## Testing
- `npm --prefix server test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad10178f348320af0a30eb2dcdcaff