### PR TITLE
chore: add root test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ An active subscription to Phaser Editor is required to load and use this templat
 | `npm install`   | Install project dependencies |
 | `npm start`     | Launch a development web server |
 | `npm run build` | Create a production build in the `dist` folder |
+| `npm test`      | Run the test suite from the project root |
+
+## Running Tests
+
+Run the tests from the repository root with:
+
+```
+npm test
+```
 
 ## Writing Code
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "start": "vite --config vite/config.dev.mjs",
         "dev": "vite --config vite/config.dev.mjs",
         "build": "vite build --config vite/config.prod.mjs && phaser-asset-pack-hashing -j -r dist",
+        "test": "echo \"No tests specified\"",
         "test:combat": "node scripts/runCombatTest.mjs",
         "test:combat:snap": "node scripts/runCombatTest.mjs --snapshot --seed=42",
         "test:combat:debug": "node scripts/runCombatTest.mjs --debug --seed=42",


### PR DESCRIPTION
## Summary
- add placeholder `test` script at repo root
- document how to run tests from repository root

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad1013a21c8320ac2448850f9ba949