### PR TITLE
Use user relation for matchmaking data

### DIFF
--- a/server/src/routes/matchmaking.ts
+++ b/server/src/routes/matchmaking.ts
@@ -38,10 +38,10 @@ router.post('/queue/join', requireAuth, async (req: AuthRequest, res) => {
 
   try {
     // Get brute data from database
-    const brute = await prisma.shacker.findUnique({ 
+    const brute = await prisma.shacker.findUnique({
       where: { id: bruteId },
       include: {
-        owner: true // Include user data
+        user: true // Include user data
       }
     });
 


### PR DESCRIPTION
## Summary
- retrieve `user` relation in matchmaking route instead of `owner`

## Testing
- `npm run build` *(fails: Could not find a declaration file for module '../../../src/engine/labrute-complete.js', etc.)*
- `npm run build` *(pass)*

------
https://chatgpt.com/codex/tasks/task_e_68ad100e04788320a4492f2a8c372605