### PR TITLE
Add combat test script to npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "start": "vite --config vite/config.dev.mjs",
         "dev": "vite --config vite/config.dev.mjs",
         "build": "vite build --config vite/config.prod.mjs && phaser-asset-pack-hashing -j -r dist",
+        "test": "npm run test:combat",
         "test:combat": "node scripts/runCombatTest.mjs",
         "test:combat:snap": "node scripts/runCombatTest.mjs --snapshot --seed=42",
         "test:combat:debug": "node scripts/runCombatTest.mjs --debug --seed=42",


### PR DESCRIPTION
## Summary
- map `npm test` to run the existing combat test suite

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad0f653cbc83208f47aa7553f8c6a3