### PR TITLE
Sync skill modifiers with official LaBrute data

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
         "test:combat:debug": "node scripts/runCombatTest.mjs --debug --seed=42",
         "test:combat:debug:pets": "node scripts/runCombatTest.mjs --debug --pets --petA=panther --petB=dog1 --seed=42 --snapshot --output=.snapshots/fights/seed-42-debug-pets.json",
         "test:combat:exact": "node scripts/runCombatTest.mjs --formulas=exact",
-        "test:combat:exact:debug": "node scripts/runCombatTest.mjs --formulas=exact --debug --seed=42"
+        "test:combat:exact:debug": "node scripts/runCombatTest.mjs --formulas=exact --debug --seed=42",
+        "test:skills": "node scripts/test-skills-compare.mjs"
     },
     "devDependencies": {
         "phaser-asset-pack-hashing": "^1.0.6",

--- a/scripts/test-skills-compare.mjs
+++ b/scripts/test-skills-compare.mjs
@@ -1,0 +1,67 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { SkillModifiers } from '../src/game/skills.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Map of FightStat enum keys to their string values
+const fightStatMap = {
+  REVERSAL: 'reversal',
+  COUNTER: 'counter',
+  EVASION: 'evasion',
+  DEXTERITY: 'dexterity',
+  BLOCK: 'block',
+  ACCURACY: 'accuracy',
+  DISARM: 'disarm',
+  COMBO: 'combo',
+  DEFLECT: 'deflect',
+  ARMOR: 'armor',
+  DAMAGE: 'damage',
+  CRITICAL_CHANCE: 'criticalChance',
+  CRITICAL_DAMAGE: 'criticalDamage',
+  HIT_SPEED: 'hitSpeed',
+  INITIATIVE: 'initiative',
+  STRENGTH: 'strength',
+  AGILITY: 'agility',
+  SPEED: 'speed',
+  ENDURANCE: 'endurance',
+  REGENERATION: 'regeneration',
+};
+
+const officialPath = path.resolve(__dirname, '../external/labrute-main-20250820-001440/labrute-main/core/src/brute/skills.ts');
+const content = fs.readFileSync(officialPath, 'utf8');
+
+// Extract SkillModifiers object from official file
+const match = content.match(/export const SkillModifiers[^=]*= ({[\s\S]*?});\n\nexport const SkillDamageModifiers/);
+if (!match) {
+  console.error('Failed to locate SkillModifiers in official file');
+  process.exit(1);
+}
+
+let objStr = match[1]
+  .replace(/\[SkillName\.([a-zA-Z0-9_]+)\]/g, '"$1"')
+  .replace(/\[FightStat\.([A-Z_]+)\]/g, (_, p1) => `"${fightStatMap[p1]}"`)
+  .replace(/WeaponType\.([A-Z_]+)/g, (_, p1) => `"${p1.toLowerCase()}"`);
+
+// Evaluate sanitized object
+const official = eval('(' + objStr + ')');
+
+const differences = [];
+for (const [skill, mods] of Object.entries(official)) {
+  const ours = SkillModifiers[skill] || {};
+  if (JSON.stringify(ours) !== JSON.stringify(mods)) {
+    differences.push({ skill, official: JSON.stringify(mods), ours: JSON.stringify(ours) });
+  }
+}
+
+console.log('Total skills compared:', Object.keys(official).length);
+if (differences.length) {
+  console.table(differences);
+  console.error(`Differences found: ${differences.length}`);
+  process.exitCode = 1;
+} else {
+  console.log('All skill modifiers match official values!');
+}
+

--- a/src/engine/CombatEngine.js
+++ b/src/engine/CombatEngine.js
@@ -684,10 +684,11 @@ export class CombatEngine {
     finalDamage = Math.max(1, finalDamage - Math.floor(effectiveDefense * 0.5));
     
     // Weapon-specific critical hit chances via formulas adapter
-    const criticalChance = this.formulas.computeCritChance(attacker.weaponType);
+    const criticalChance = this.formulas.computeCritChance(attacker.stats, attacker.weaponType);
     const critical = this.rng.float() < criticalChance;
+    const critMultiplier = this.formulas.computeCritDamageMultiplier(attacker.stats);
     if (critical) {
-      finalDamage *= 2;
+      finalDamage = Math.floor(finalDamage * critMultiplier);
     }
     this.logDebug('damage_calc', {
       attacker: attacker.stats.name,

--- a/src/engine/formulas.labrute.js
+++ b/src/engine/formulas.labrute.js
@@ -14,6 +14,7 @@ export {
   computeBaseDamage,
   computeDamageVariation,
   computeCritChance,
+  computeCritDamageMultiplier,
   computeComboChance,
   computeMaxCombo,
 } from './formulas.js';

--- a/src/game/skills.js
+++ b/src/game/skills.js
@@ -1,10 +1,14 @@
+import { WeaponType } from './weapons.js';
+
+// Official skill names from LaBrute core
 export const SkillName = {
   herculeanStrength: 'herculeanStrength',
   felineAgility: 'felineAgility',
   lightningBolt: 'lightningBolt',
   vitality: 'vitality',
   immortality: 'immortality',
-  weaponMaster: 'weaponMaster',
+  reconnaissance: 'reconnaissance',
+  weaponsMaster: 'weaponsMaster',
   martialArts: 'martialArts',
   sixthSense: 'sixthSense',
   hostility: 'hostility',
@@ -23,7 +27,6 @@ export const SkillName = {
   determination: 'determination',
   firstStrike: 'firstStrike',
   resistant: 'resistant',
-  reconnaissance: 'reconnaissance',
   counterAttack: 'counterAttack',
   ironHead: 'ironHead',
   thief: 'thief',
@@ -40,10 +43,6 @@ export const SkillName = {
   chef: 'chef',
   spy: 'spy',
   saboteur: 'saboteur',
-  strongWill: 'strongWill',
-  potion: 'potion',
-  repulse: 'repulse',
-  trickster: 'trickster',
   backup: 'backup',
   hideaway: 'hideaway',
   monk: 'monk',
@@ -51,11 +50,14 @@ export const SkillName = {
   chaining: 'chaining',
   haste: 'haste',
   treat: 'treat',
+  repulse: 'repulse',
   fastMetabolism: 'fastMetabolism',
 };
 
+// Official fight stat identifiers
 export const FightStat = {
   REVERSAL: 'reversal',
+  COUNTER: 'counter',
   EVASION: 'evasion',
   DEXTERITY: 'dexterity',
   BLOCK: 'block',
@@ -63,142 +65,111 @@ export const FightStat = {
   DISARM: 'disarm',
   COMBO: 'combo',
   DEFLECT: 'deflect',
-  TEMPO: 'tempo',
-  COUNTER: 'counter',
-  ENDURANCE: 'endurance',
+  ARMOR: 'armor',
+  DAMAGE: 'damage',
+  CRITICAL_CHANCE: 'criticalChance',
+  CRITICAL_DAMAGE: 'criticalDamage',
+  HIT_SPEED: 'hitSpeed',
+  INITIATIVE: 'initiative',
   STRENGTH: 'strength',
   AGILITY: 'agility',
   SPEED: 'speed',
-  INITIATIVE: 'initiative',
+  ENDURANCE: 'endurance',
+  REGENERATION: 'regeneration',
 };
 
+// Skill modifiers copied from official LaBrute core (units preserved)
 export const SkillModifiers = {
   [SkillName.herculeanStrength]: {
-    [FightStat.STRENGTH]: { percent: 0.5, flat: 3 },
-    [FightStat.DEXTERITY]: { percent: -0.3 },
+    [FightStat.STRENGTH]: { flat: 3, percent: 0.5 },
   },
   [SkillName.felineAgility]: {
-    [FightStat.AGILITY]: { percent: 0.5, flat: 3 },
-    [FightStat.ACCURACY]: { percent: -0.3 },
+    [FightStat.AGILITY]: { flat: 3, percent: 0.5 },
   },
   [SkillName.lightningBolt]: {
-    [FightStat.SPEED]: { percent: 0.5, flat: 3 },
-    [FightStat.INITIATIVE]: { flat: -0.3 },
+    [FightStat.SPEED]: { flat: 3, percent: 0.5 },
   },
   [SkillName.vitality]: {
-    [FightStat.ENDURANCE]: { percent: 0.5, flat: 3 },
-    [FightStat.STRENGTH]: { percent: -0.3 },
+    [FightStat.ENDURANCE]: { flat: 3, percent: 0.5 },
   },
   [SkillName.immortality]: {
-    [FightStat.ENDURANCE]: { flat: 250 },
-    [FightStat.STRENGTH]: { flat: -8 },
-    [FightStat.AGILITY]: { flat: -8 },
-    [FightStat.SPEED]: { flat: -8 },
+    [FightStat.ENDURANCE]: { percent: 2.5 },
+    [FightStat.STRENGTH]: { percent: -0.25 },
+    [FightStat.AGILITY]: { percent: -0.25 },
+    [FightStat.SPEED]: { percent: -0.25 },
   },
-  [SkillName.weaponMaster]: {
-    [FightStat.DEXTERITY]: { percent: 0.5 },
-    [FightStat.ACCURACY]: { percent: 0.1 },
+  [SkillName.weaponsMaster]: {
+    [FightStat.DAMAGE]: { percent: 0.5, weaponType: WeaponType.SHARP },
   },
   [SkillName.martialArts]: {
-    [FightStat.COUNTER]: { percent: 1 },
-    [FightStat.COMBO]: { percent: 0.5 },
-    [FightStat.BLOCK]: { percent: -0.2 },
+    [FightStat.DAMAGE]: { percent: 1, weaponType: null },
   },
   [SkillName.sixthSense]: {
-    [FightStat.COUNTER]: { percent: 0.5 },
-    [FightStat.BLOCK]: { percent: 0.25 },
-    [FightStat.EVASION]: { percent: 0.1 },
+    [FightStat.COUNTER]: { percent: 0.1 },
   },
   [SkillName.hostility]: {
-    [FightStat.REVERSAL]: { percent: 0.5 },
-    [FightStat.COUNTER]: { percent: 0.3 },
+    [FightStat.REVERSAL]: { percent: 0.3 },
   },
   [SkillName.fistsOfFury]: {
-    [FightStat.COMBO]: { percent: 0.5 },
-    [FightStat.DEXTERITY]: { percent: 0.2 },
+    [FightStat.COMBO]: { percent: 0.2 },
   },
   [SkillName.shield]: {
     [FightStat.BLOCK]: { percent: 0.45 },
+    [FightStat.DAMAGE]: { percent: -0.25 },
   },
   [SkillName.armor]: {
-    [FightStat.BLOCK]: { percent: 0.3 },
-    [FightStat.SPEED]: { flat: -2 },
+    [FightStat.ARMOR]: { percent: 0.25 },
+    [FightStat.SPEED]: { percent: -0.15 },
   },
   [SkillName.toughenedSkin]: {
-    [FightStat.BLOCK]: { percent: 0.15 },
+    [FightStat.ARMOR]: { percent: 0.1 },
   },
   [SkillName.untouchable]: {
-    [FightStat.EVASION]: { percent: 0.5 },
+    [FightStat.EVASION]: { percent: 0.3 },
   },
-  [SkillName.sabotage]: {
-    [FightStat.DISARM]: { percent: 2.5 },
-  },
+  [SkillName.sabotage]: {},
   [SkillName.shock]: {
     [FightStat.DISARM]: { percent: 0.5 },
-    [FightStat.INITIATIVE]: { flat: -0.1 },
   },
   [SkillName.bodybuilder]: {
-    [FightStat.STRENGTH]: { flat: 3 },
-    [FightStat.ENDURANCE]: { flat: 3 },
-    [FightStat.AGILITY]: { flat: 3 },
-    [FightStat.SPEED]: { flat: 3 },
+    [FightStat.HIT_SPEED]: { percent: 0.40, weaponType: WeaponType.HEAVY },
+    [FightStat.DEXTERITY]: { percent: 0.1, weaponType: WeaponType.HEAVY },
   },
   [SkillName.relentless]: {
-    [FightStat.ENDURANCE]: { flat: 4 },
-    [FightStat.ACCURACY]: { percent: -0.3 },
-  },
-  [SkillName.survival]: {
-    [FightStat.ENDURANCE]: { flat: 11 },
-  },
-  [SkillName.leadSkeleton]: {
-    [FightStat.ENDURANCE]: { flat: 5 },
-    [FightStat.SPEED]: { flat: -1 },
-  },
-  [SkillName.balletShoes]: {
-    [FightStat.EVASION]: { percent: 0.18 },
-    [FightStat.DEXTERITY]: { percent: 0.18 },
-  },
-  [SkillName.determination]: {
-    [FightStat.ENDURANCE]: { flat: 2 },
-    [FightStat.STRENGTH]: { flat: 2 },
-    [FightStat.AGILITY]: { flat: 2 },
-    [FightStat.SPEED]: { flat: 2 },
-  },
-  [SkillName.firstStrike]: {
-    [FightStat.INITIATIVE]: { flat: 2 },
-  },
-  [SkillName.resistant]: {
-    [FightStat.SPEED]: { flat: 4 },
-  },
-  [SkillName.reconnaissance]: {
-    [FightStat.SPEED]: { flat: 5 },
-    [FightStat.INITIATIVE]: { flat: 0.4 },
-    [FightStat.STRENGTH]: { flat: -2 },
-  },
-  [SkillName.counterAttack]: {
-    [FightStat.COUNTER]: { percent: 0.9 },
-    [FightStat.INITIATIVE]: { flat: -0.1 },
-  },
-  [SkillName.ironHead]: {
-    [FightStat.BLOCK]: { percent: -0.5 },
-    [FightStat.EVASION]: { percent: -0.5 },
     [FightStat.ACCURACY]: { percent: 0.3 },
   },
-  [SkillName.thief]: {
-    [FightStat.DISARM]: { percent: 0.5 },
-    [FightStat.INITIATIVE]: { flat: 0.2 },
+  [SkillName.survival]: {
+    [FightStat.BLOCK]: { percent: 0.2, details: 'atOneHp' },
+    [FightStat.EVASION]: { percent: 0.2, details: 'atOneHp' },
   },
+  [SkillName.leadSkeleton]: {
+    [FightStat.ARMOR]: { percent: 0.15 },
+    [FightStat.DAMAGE]: { percent: -0.15, weaponType: WeaponType.BLUNT, opponent: true },
+    [FightStat.EVASION]: { percent: -0.15 },
+  },
+  [SkillName.balletShoes]: {
+    [FightStat.EVASION]: { percent: 0.1 },
+  },
+  [SkillName.determination]: {},
+  [SkillName.firstStrike]: {
+    [FightStat.INITIATIVE]: { flat: 200 },
+  },
+  [SkillName.resistant]: {},
+  [SkillName.reconnaissance]: {
+    [FightStat.INITIATIVE]: { flat: -200 },
+    [FightStat.SPEED]: { flat: 5, percent: 1.5 },
+    [FightStat.CRITICAL_DAMAGE]: { percent: 0.5 },
+  },
+  [SkillName.counterAttack]: {
+    [FightStat.BLOCK]: { percent: 0.1 },
+    [FightStat.REVERSAL]: { percent: 0.9, details: 'afterBlock' },
+  },
+  [SkillName.ironHead]: {},
+  [SkillName.thief]: {},
   [SkillName.fierceBrute]: {
-    [FightStat.STRENGTH]: { flat: 4 },
-    [FightStat.BLOCK]: { percent: -0.3 },
+    [FightStat.CRITICAL_CHANCE]: { percent: 0.1 },
   },
-  [SkillName.tragicPotion]: {
-    [FightStat.STRENGTH]: { flat: -1 },
-    [FightStat.AGILITY]: { flat: -1 },
-    [FightStat.SPEED]: { flat: -1 },
-    [FightStat.ENDURANCE]: { flat: 5 },
-    [FightStat.INITIATIVE]: { flat: 0.1 },
-  },
+  [SkillName.tragicPotion]: {},
   [SkillName.net]: {},
   [SkillName.bomb]: {},
   [SkillName.hammer]: {},
@@ -210,55 +181,40 @@ export const SkillModifiers = {
   [SkillName.chef]: {},
   [SkillName.spy]: {},
   [SkillName.saboteur]: {},
-  [SkillName.strongWill]: {},
-  [SkillName.potion]: {},
-  [SkillName.repulse]: {},
-  [SkillName.trickster]: {
-    [FightStat.EVASION]: { percent: 0.2 },
-    [FightStat.DEXTERITY]: { percent: 0.2 },
-    [FightStat.COUNTER]: { percent: 0.2 },
-  },
-  [SkillName.backup]: {
-    // Backup doesn't modify stats, it's handled in combat
-  },
+  [SkillName.backup]: {},
   [SkillName.hideaway]: {
-    [FightStat.EVASION]: { percent: 0.25 },
-    [FightStat.INITIATIVE]: { flat: -0.2 },
+    [FightStat.BLOCK]: { percent: 0.25, details: 'againstThrows' },
   },
   [SkillName.monk]: {
     [FightStat.COUNTER]: { percent: 0.4 },
-    [FightStat.SPEED]: { flat: 6 },
-    [FightStat.STRENGTH]: { flat: -4 },
+    [FightStat.INITIATIVE]: { flat: -200 },
+    [FightStat.HIT_SPEED]: { percent: -1 },
   },
-  [SkillName.vampirism]: {
-    // Vampirism is handled in combat mechanics
-    [FightStat.ENDURANCE]: { flat: -3 },
-  },
-  [SkillName.chaining]: {
-    [FightStat.COMBO]: { percent: 0.3 },
-    [FightStat.DEXTERITY]: { percent: 0.15 },
-  },
+  [SkillName.vampirism]: {},
+  [SkillName.chaining]: {},
   [SkillName.haste]: {
-    [FightStat.SPEED]: { percent: 0.3 },
-    [FightStat.INITIATIVE]: { flat: -0.4 },
+    [FightStat.CRITICAL_CHANCE]: { percent: 0.05 },
   },
-  [SkillName.treat]: {
-    // Treat is a combat ability, no stat modifiers
+  [SkillName.treat]: {},
+  [SkillName.repulse]: {
+    [FightStat.DEFLECT]: { percent: 0.3 },
+    [FightStat.CRITICAL_CHANCE]: { percent: 0.05 },
   },
   [SkillName.fastMetabolism]: {
-    [FightStat.ENDURANCE]: { flat: 2 },
-    // Regeneration handled in combat
+    [FightStat.REGENERATION]: { percent: 0.01 },
+    [FightStat.HIT_SPEED]: { percent: -0.5 },
+    [FightStat.CRITICAL_CHANCE]: { percent: -0.05 },
   },
 };
 
 export function applySkillModifiers(fighter, skill) {
   const modifiers = SkillModifiers[skill];
   if (!modifiers) return fighter;
-  
+
   const updatedFighter = { ...fighter };
-  
+
   Object.entries(modifiers).forEach(([stat, modifier]) => {
-    switch(stat) {
+    switch (stat) {
       case FightStat.ENDURANCE:
         if (modifier.flat) updatedFighter.stats.maxHealth += modifier.flat * 2;
         if (modifier.percent) updatedFighter.stats.maxHealth *= (1 + modifier.percent);
@@ -308,63 +264,63 @@ export function applySkillModifiers(fighter, skill) {
       case FightStat.REVERSAL:
         if (modifier.percent) updatedFighter.stats.reversalChance = (updatedFighter.stats.reversalChance || 0) + modifier.percent;
         break;
+      case FightStat.CRITICAL_CHANCE:
+        if (modifier.percent) updatedFighter.stats.criticalChance = (updatedFighter.stats.criticalChance || 0) + modifier.percent;
+        break;
+      case FightStat.CRITICAL_DAMAGE:
+        if (modifier.percent) updatedFighter.stats.criticalDamage = (updatedFighter.stats.criticalDamage || 0) + modifier.percent;
+        break;
+      case FightStat.REGENERATION:
+        if (modifier.percent) updatedFighter.stats.regeneration = (updatedFighter.stats.regeneration || 0) + modifier.percent;
+        break;
     }
   });
-  
+
   // Ensure stats don't go below minimum values
   updatedFighter.stats.strength = Math.max(1, Math.floor(updatedFighter.stats.strength));
   updatedFighter.stats.agility = Math.max(0, Math.floor(updatedFighter.stats.agility));
   updatedFighter.stats.defense = Math.max(0, Math.floor(updatedFighter.stats.defense));
   updatedFighter.stats.health = Math.max(1, Math.floor(updatedFighter.stats.health));
   updatedFighter.stats.maxHealth = Math.max(1, Math.floor(updatedFighter.stats.maxHealth));
-  
+
   return updatedFighter;
 }
 
 export function getRandomSkill(excludeSkills = []) {
-  const availableSkills = Object.keys(SkillName).filter(skill => !excludeSkills.includes(skill));
+  const availableSkills = Object.keys(SkillName).filter((skill) => !excludeSkills.includes(skill));
   const randomIndex = Math.floor(Math.random() * availableSkills.length);
   return SkillName[availableSkills[randomIndex]];
 }
 
 export const skillDescriptions = {
-  [SkillName.herculeanStrength]: "Massive strength boost (+50% STR, +3 flat)",
-  [SkillName.felineAgility]: "Enhanced agility (+50% AGI, +3 flat)",
-  [SkillName.lightningBolt]: "Lightning speed (+50% SPD, +3 flat)",
-  [SkillName.vitality]: "Increased health (+50% END, +3 flat)",
-  [SkillName.immortality]: "Massive health boost (+250 HP) but weakens other stats",
-  [SkillName.weaponMaster]: "Better weapon handling (+50% dexterity)",
-  [SkillName.martialArts]: "Master of combos and counters",
-  [SkillName.sixthSense]: "Enhanced defensive awareness",
-  [SkillName.hostility]: "Increased aggression and reversals",
-  [SkillName.fistsOfFury]: "Combo specialist",
-  [SkillName.shield]: "Strong blocking ability (+45%)",
-  [SkillName.armor]: "Good protection but slower",
-  [SkillName.toughenedSkin]: "Natural armor (+15% block)",
-  [SkillName.untouchable]: "Hard to hit (+50% evasion)",
-  [SkillName.sabotage]: "Master of disarming",
-  [SkillName.shock]: "Disarms and stuns enemies",
-  [SkillName.bodybuilder]: "All stats increased (+3 each)",
-  [SkillName.relentless]: "Never gives up (+4 END)",
-  [SkillName.survival]: "Built to last (+11 END)",
-  [SkillName.leadSkeleton]: "Heavy but durable",
-  [SkillName.balletShoes]: "Graceful dodger",
-  [SkillName.determination]: "Well-rounded fighter (+2 all)",
-  [SkillName.firstStrike]: "Always attacks first",
-  [SkillName.resistant]: "Fast recovery (+4 SPD)",
-  [SkillName.reconnaissance]: "Scout: fast but weaker",
-  [SkillName.counterAttack]: "Counter specialist (+90%)",
-  [SkillName.ironHead]: "Can't dodge but always hits",
-  [SkillName.thief]: "Steals weapons easily",
-  [SkillName.fierceBrute]: "Strong but can't block well",
-  [SkillName.tragicPotion]: "Mixed blessing: tough but weak",
-  [SkillName.trickster]: "Unpredictable fighter",
-  [SkillName.backup]: "Can call backup brutes to help in combat",
-  [SkillName.hideaway]: "Can hide during combat (+25% evasion)",
-  [SkillName.monk]: "Martial arts master (+40% counter, +6 speed)",
-  [SkillName.vampirism]: "Heals by dealing damage",
-  [SkillName.chaining]: "Chain attacks together (+30% combo)",
-  [SkillName.haste]: "Super fast attacks (+30% speed)",
-  [SkillName.treat]: "Can heal during combat",
-  [SkillName.fastMetabolism]: "Regenerates health each turn",
+  [SkillName.herculeanStrength]: 'Massive strength boost (+50% STR, +3 flat)',
+  [SkillName.felineAgility]: 'Enhanced agility (+50% AGI, +3 flat)',
+  [SkillName.lightningBolt]: 'Lightning speed (+50% SPD, +3 flat)',
+  [SkillName.vitality]: 'Increased health (+50% END, +3 flat)',
+  [SkillName.immortality]: 'Massive health boost (+250% END) but weakens other stats',
+  [SkillName.weaponsMaster]: 'Better weapon handling with sharp weapons',
+  [SkillName.martialArts]: 'Master of combos and counters',
+  [SkillName.sixthSense]: 'Enhanced defensive awareness',
+  [SkillName.hostility]: 'Increased aggression and reversals',
+  [SkillName.fistsOfFury]: 'Combo specialist',
+  [SkillName.shield]: 'Strong blocking ability (+45%)',
+  [SkillName.armor]: 'Good protection but slower',
+  [SkillName.toughenedSkin]: 'Natural armor (+10%)',
+  [SkillName.untouchable]: 'Hard to hit (+30% evasion)',
+  [SkillName.shock]: 'Disarms enemies',
+  [SkillName.bodybuilder]: 'Stronger with heavy weapons',
+  [SkillName.relentless]: 'Accuracy boost (+30%)',
+  [SkillName.survival]: 'Bonuses when at 1 HP',
+  [SkillName.leadSkeleton]: 'Heavy but durable',
+  [SkillName.balletShoes]: 'Graceful dodger',
+  [SkillName.firstStrike]: 'Always attacks first',
+  [SkillName.reconnaissance]: 'Scout: much faster but fragile',
+  [SkillName.counterAttack]: 'Counter specialist',
+  [SkillName.fierceBrute]: 'Higher critical chance (+10%)',
+  [SkillName.hideaway]: 'Can hide against throws',
+  [SkillName.monk]: 'Counter-focused but slower attacks',
+  [SkillName.haste]: 'Slight critical chance boost',
+  [SkillName.repulse]: 'Deflects attacks and boosts crit chance',
+  [SkillName.fastMetabolism]: 'Regenerates health each turn',
 };
+


### PR DESCRIPTION
## Summary
- mirror official LaBrute skill modifiers and stat enums, including critical damage
- support critical chance/damage bonuses in formulas and combat damage
- add test to compare local skills against official data

## Testing
- `npm run test:skills`
- `npm run test:combat`


------
https://chatgpt.com/codex/tasks/task_e_68ad0caeb5c48320a1d063237c0a1700