### PR TITLE
feat: aggregate fighter stats and apply skill damage multipliers

### DIFF
--- a/src/engine/CombatEngine.js
+++ b/src/engine/CombatEngine.js
@@ -659,45 +659,27 @@ export class CombatEngine {
       };
     }
     
-    // Calculate base damage via formulas adapter
-    let baseDamage = this.formulas.computeBaseDamage(attacker.stats, attacker.hasWeapon, attacker.weaponType);
-    
-    // Berserker rage DISABLED for faster combat
-    // if (attacker.specialMoves.active.berserkerRage) {
-    //   baseDamage *= this.specialMoves.berserkerRage.multiplier;
-    // }
-    
-    // RNG damage variation (±25%)
-    const damageVariation = this.formulas.computeDamageVariation(this.rng);
-    let finalDamage = Math.floor(baseDamage * damageVariation * damageModifier);
-    
+    // Calculate damage via formulas adapter (includes crit handling)
+    const dmgRes = this.formulas.computeDamage(attacker, defender, this.rng, damageModifier);
+    let finalDamage = dmgRes.damage;
+
     // Apply defense
     let effectiveDefense = defender.stats.defense;
-    
+
     // Defensive shield DISABLED for faster combat
     // if (defender.specialMoves.active.defensiveShield) {
     //   finalDamage *= this.specialMoves.defensiveShield.multiplier;
     // }
-    
+
     // La défense réduit les dégâts mais ne peut pas les annuler complètement
     // Minimum 1 dégât si l'attaque touche
     finalDamage = Math.max(1, finalDamage - Math.floor(effectiveDefense * 0.5));
-    
-    // Weapon-specific critical hit chances via formulas adapter
-    const criticalChance = this.formulas.computeCritChance(attacker.weaponType);
-    const critical = this.rng.float() < criticalChance;
-    if (critical) {
-      finalDamage *= 2;
-    }
+
     this.logDebug('damage_calc', {
       attacker: attacker.stats.name,
       defender: defender.stats.name,
-      baseDamage,
-      damageVariation,
-      effectiveDefense,
-      criticalChance,
-      critical,
       finalDamage,
+      critical: dmgRes.critical,
       damageModifier
     });
     

--- a/tests/formulas.test.js
+++ b/tests/formulas.test.js
@@ -1,0 +1,49 @@
+import assert from 'assert';
+import { computeCritChance, computeDamage, computeBaseDamage, computeDamageVariation } from '../src/engine/formulas.js';
+import { WeaponName, weaponStats } from '../src/game/weapons.js';
+import { SkillName } from '../src/game/skills.js';
+import { RNG } from '../src/engine/rng.js';
+
+// Test critical chance aggregation
+(function testCritChance() {
+  const fighter = {
+    stats: { skills: [] },
+    hasWeapon: true,
+    weaponType: WeaponName.knife,
+  };
+  const critChance = computeCritChance(fighter);
+  assert.strictEqual(critChance, weaponStats[WeaponName.knife].critChance);
+})();
+
+// Test damage with skill modifiers and seed
+(function testDamageWithSkills() {
+  const attacker = {
+    stats: { strength: 10, skills: [SkillName.herculeanStrength] },
+    hasWeapon: true,
+    weaponType: WeaponName.knife,
+  };
+  const defender = {
+    stats: { defense: 0, skills: [SkillName.armor] },
+    hasWeapon: false,
+  };
+
+  const rng1 = new RNG('damage');
+  const result = computeDamage(attacker, defender, rng1);
+
+  // Recompute expected manually with same seed
+  const rng2 = new RNG('damage');
+  const base = computeBaseDamage(attacker.stats, attacker.hasWeapon, attacker.weaponType);
+  const variation = computeDamageVariation(rng2);
+  const critRoll = rng2.float();
+  const skillsMultiplier = (1 + 0.5) * (1 - 0.25);
+  let expected = Math.floor(base * variation * skillsMultiplier);
+  const critChance = weaponStats[attacker.weaponType].critChance;
+  const critical = critRoll < critChance;
+  if (critical) {
+    expected = Math.floor(expected * 2);
+  }
+  assert.strictEqual(result.damage, expected);
+  assert.strictEqual(result.critical, critical);
+})();
+
+console.log('formulas tests passed');


### PR DESCRIPTION
## Summary
- add `getFighterStat` to merge weapon and skill bonuses for critical stats
- apply `SkillDamageModifiers` in new `computeDamage` and remove hard-coded crit chance
- update combat engine to use new damage routine
- add parity tests for critical chance and skill multipliers

## Testing
- `node tests/formulas.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad5d563a7c8320a3b4941657f77ffa