### PR TITLE
feat: use rand-seed for deterministic RNG

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "@phaserjs/editor-scripts-base": "^1.0.0",
                 "cors": "^2.8.5",
                 "phaser": "3.80.1",
+                "rand-seed": "^3.0.0",
                 "socket.io": "^4.8.1"
             },
             "devDependencies": {
@@ -1211,6 +1212,12 @@
             "engines": {
                 "node": "^10 || ^12 || >=14"
             }
+        },
+        "node_modules/rand-seed": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/rand-seed/-/rand-seed-3.0.0.tgz",
+            "integrity": "sha512-Zy8wnL6whyIAGOX2i9Mn1Orq3t9TNizGUk8euxamr60Z3PmspwFeT+vCZPcYMAR5nOztnAKPtVi3jt8EzmCB6g==",
+            "license": "MIT"
         },
         "node_modules/reduce-flatten": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "@phaserjs/editor-scripts-base": "^1.0.0",
         "cors": "^2.8.5",
         "phaser": "3.80.1",
+        "rand-seed": "^3.0.0",
         "socket.io": "^4.8.1"
     }
 }

--- a/src/engine/CombatEngine.js
+++ b/src/engine/CombatEngine.js
@@ -19,7 +19,11 @@ export class CombatEngine {
       console.log('[CombatEngine] Utilisation du système LaBrute complet');
       // LaBruteCombatEngine attend un RNG, pas un objet options
       const rng = options.rng || new RNG();
-      const labEngine = new LaBruteCombatEngine(fighter1, fighter2, rng.random ? rng.random.bind(rng) : rng);
+      const labEngine = new LaBruteCombatEngine(
+        fighter1,
+        fighter2,
+        rng.next ? rng.next.bind(rng) : rng
+      );
       // Copier la propriété turnInProgress pour la compatibilité
       labEngine.turnInProgress = false;
       return labEngine;
@@ -586,7 +590,7 @@ export class CombatEngine {
     // Block check based on defender's defense stat
     const blockChance = this.formulas.computeBlockChance(defender.stats);
     const hasStaminaForBlock = defender.stats.stamina >= 15;
-    const blockSuccess = hasStaminaForBlock && this.rng.float() < blockChance;
+    const blockSuccess = hasStaminaForBlock && this.rng.next() < blockChance;
     this.logDebug('block_check', { attacker: attacker.stats.name, defender: defender.stats.name, blockChance, hasStaminaForBlock, blockSuccess });
     
     // Show debug indicator for block calculation (guarded)
@@ -618,7 +622,7 @@ export class CombatEngine {
     // Dodge check based on defender's agility
     // AGI provides a 0.8% chance to dodge per point.
     const dodgeChance = this.formulas.computeDodgeChance(defender.stats);
-    const dodgeSuccess = this.rng.float() < dodgeChance;
+    const dodgeSuccess = this.rng.next() < dodgeChance;
     this.logDebug('dodge_check', { attacker: attacker.stats.name, defender: defender.stats.name, dodgeChance, dodgeSuccess });
     
     // Show debug indicator for dodge calculation (guarded)
@@ -645,7 +649,7 @@ export class CombatEngine {
     let accuracy = this.formulas.computeAccuracy(attacker.stats, attacker.weaponType);
     
     // RNG hit check
-    const hit = this.rng.float() < accuracy;
+    const hit = this.rng.next() < accuracy;
     this.logDebug('hit_check', { attacker: attacker.stats.name, defender: defender.stats.name, accuracy, hit, weaponType: attacker.weaponType });
     
     if (!hit) {
@@ -685,7 +689,7 @@ export class CombatEngine {
     
     // Weapon-specific critical hit chances via formulas adapter
     const criticalChance = this.formulas.computeCritChance(attacker.weaponType);
-    const critical = this.rng.float() < criticalChance;
+    const critical = this.rng.next() < criticalChance;
     if (critical) {
       finalDamage *= 2;
     }
@@ -912,7 +916,7 @@ export class CombatEngine {
     
     // Defender can try to dodge the throw
     const dodgeChance = defender.stats.agility * 0.006; // Lower dodge chance vs throws
-    const dodgeSuccess = this.rng.float() < dodgeChance;
+    const dodgeSuccess = this.rng.next() < dodgeChance;
     this.logDebug('throw_dodge_check', { attacker: attacker.stats.name, defender: defender.stats.name, dodgeChance, dodgeSuccess });
     
     // Show debug indicator for weapon throw dodge calculation (guarded)
@@ -1009,7 +1013,7 @@ export class CombatEngine {
     // }
     
     // RNG damage variation
-    const damageVariation = 0.8 + (this.rng.float() * 0.4); // Less variation for throws
+    const damageVariation = 0.8 + (this.rng.next() * 0.4); // Less variation for throws
     let finalDamage = Math.floor(baseDamage * damageVariation);
     
     // Apply defense (reduced effectiveness against thrown weapons)
@@ -1394,7 +1398,7 @@ export class CombatEngine {
         const target = this.getRandomTarget(backup);
         if (target) {
           // Backup performs a simple attack
-          const damage = Math.floor(backup.stats.strength * 0.8 + this.rng.float() * 10);
+          const damage = Math.floor(backup.stats.strength * 0.8 + this.rng.next() * 10);
           
           if (target.isBackup) {
             this.handleBackupDamage(target, damage);

--- a/src/engine/formulas.js
+++ b/src/engine/formulas.js
@@ -69,7 +69,7 @@ function getAdjustedStats(stats) {
  * Mirrors existing engine: baseInitiative - speed*0.01 + rand(0..0.1)
  */
 export function computeInitiative(stats, rng) {
-  const jitter = rng.float() * 0.1; // [0, 0.1)
+  const jitter = rng.next() * 0.1; // [0, 0.1)
   const agg = aggregateFromSkills(stats && stats.skills);
   const adjustedSpeed = getAdjustedStats(stats).speed;
   // Lower is earlier. Positive initiative bonuses reduce final value.
@@ -90,7 +90,7 @@ export function computeCounterChance(stats) {
  */
 export function computeCounterDamage(stats, rng) {
   const adjusted = getAdjustedStats(stats);
-  return Math.floor(adjusted.strength * 0.5 * (0.8 + rng.float() * 0.4));
+  return Math.floor(adjusted.strength * 0.5 * (0.8 + rng.next() * 0.4));
 }
 
 /**
@@ -110,7 +110,7 @@ export function computeBlockChance(stats) {
  */
 export function computeBlockDamage(attackerStats, rng, damageReduction = 0.75) {
   const adjusted = getAdjustedStats(attackerStats);
-  const potentialDamage = Math.floor(adjusted.strength * (0.75 + (rng.float() * 0.5)));
+  const potentialDamage = Math.floor(adjusted.strength * (0.75 + (rng.next() * 0.5)));
   const blockedDamage = Math.floor(potentialDamage * damageReduction);
   return potentialDamage - blockedDamage;
 }
@@ -187,7 +187,7 @@ export function computeBaseDamage(attackerStats, hasWeapon, weaponType) {
  * Donne une variation entre 0.8 et 1.2 (±20%)
  */
 export function computeDamageVariation(rng) {
-  return 0.8 + (rng.float() * 0.4);
+  return 0.8 + (rng.next() * 0.4);
 }
 
 /**

--- a/src/engine/rng.js
+++ b/src/engine/rng.js
@@ -1,60 +1,33 @@
-// Seedable RNG utility for deterministic combat simulations
-// Mulberry32 PRNG with xmur3 hashing for string seeds
+import Rand from 'rand-seed';
 
-function xmur3(str) {
-  let h = 1779033703 ^ str.length;
-  for (let i = 0; i < str.length; i++) {
-    h = Math.imul(h ^ str.charCodeAt(i), 3432918353);
-    h = (h << 13) | (h >>> 19);
-  }
-  return function () {
-    h = Math.imul(h ^ (h >>> 16), 2246822507);
-    h = Math.imul(h ^ (h >>> 13), 3266489909);
-    h ^= h >>> 16;
-    return h >>> 0;
-  };
-}
-
+// Wrapper around `rand-seed` providing utility helpers used by the engine.
 export class RNG {
   constructor(seed = Date.now()) {
     this.setSeed(seed);
   }
 
   setSeed(seed) {
-    let n;
-    if (typeof seed === 'string') {
-      const hash = xmur3(seed);
-      n = hash();
-    } else if (typeof seed === 'number') {
-      n = seed >>> 0;
-    } else {
-      n = Date.now() >>> 0;
-    }
-    if (n === 0) n = 0x9e3779b9; // avoid zero seed
-    this._state = n >>> 0;
+    this.rand = new Rand(seed);
   }
 
-  // Mulberry32 step, returns float in [0,1)
+  // Core random method returning a float in [0,1)
+  next() {
+    return this.rand.next();
+  }
+
+  // Legacy helpers built on top of `next()`
   float() {
-    let t = (this._state += 0x6D2B79F5);
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    const result = ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-    this._state = this._state >>> 0;
-    return result;
+    return this.next();
   }
 
-  // Integer in [min, max] inclusive
   int(min, max) {
     if (max < min) [min, max] = [max, min];
-    const r = this.float();
-    return Math.floor(r * (max - min + 1)) + min;
+    return Math.floor(this.next() * (max - min + 1)) + min;
   }
 
-  // Returns true with probability p (0..1)
   chance(p) {
     if (p <= 0) return false;
     if (p >= 1) return true;
-    return this.float() < p;
+    return this.next() < p;
   }
 }

--- a/src/game/pets.js
+++ b/src/game/pets.js
@@ -158,13 +158,13 @@ export class Pet {
   }
 
   canAssist() {
-    const roll = this.rng ? this.rng.float() : Math.random();
+    const roll = this.rng ? this.rng.next() : Math.random();
     return this.isAlive && roll < this.assistChance;
   }
 
   calculateDamage() {
     const baseDamage = this.stats.damage + this.stats.strength * 0.5;
-    const variation = 0.8 + (this.rng ? this.rng.float() : Math.random()) * 0.4;
+    const variation = 0.8 + (this.rng ? this.rng.next() : Math.random()) * 0.4;
     return Math.floor(baseDamage * variation);
   }
 
@@ -182,7 +182,7 @@ export class Pet {
         effect.damage = Math.floor(damage * 1.5);
         effect.message = `${this.name} mauls the target for ${effect.damage} damage!`;
         effect.specialEffect = 'bleed';
-        if ((this.rng ? this.rng.float() : Math.random()) < 0.3) {
+        if ((this.rng ? this.rng.next() : Math.random()) < 0.3) {
           effect.statusEffect = { type: 'bleed', duration: 2, damage: 3 };
         }
         break;
@@ -190,7 +190,7 @@ export class Pet {
       case 'pounce':
         effect.damage = damage;
         effect.message = `${this.name} pounces for ${damage} damage!`;
-        if ((this.rng ? this.rng.float() : Math.random()) < 0.4) {
+        if ((this.rng ? this.rng.next() : Math.random()) < 0.4) {
           effect.statusEffect = { type: 'stun', duration: 1 };
           effect.message += ' Target is stunned!';
         }
@@ -199,13 +199,13 @@ export class Pet {
       case 'bite':
         effect.damage = damage;
         effect.message = `${this.name} bites for ${damage} damage!`;
-        if ((this.rng ? this.rng.float() : Math.random()) < 0.2) {
+        if ((this.rng ? this.rng.next() : Math.random()) < 0.2) {
           effect.statusEffect = { type: 'weaken', duration: 2, modifier: 0.8 };
         }
         break;
 
       case 'guard':
-        if ((this.rng ? this.rng.float() : Math.random()) < 0.5) {
+        if ((this.rng ? this.rng.next() : Math.random()) < 0.5) {
           this.owner.stats.defense += 5;
           effect.damage = 0;
           effect.message = `${this.name} guards ${this.owner.stats.name}, increasing defense!`;
@@ -243,7 +243,7 @@ export function getRandomPet(rng) {
   ];
   
   const totalWeight = weights.reduce((sum, item) => sum + item.weight, 0);
-  let random = (rng ? rng.float() : Math.random()) * totalWeight;
+  let random = (rng ? rng.next() : Math.random()) * totalWeight;
   
   for (const item of weights) {
     random -= item.weight;

--- a/src/scenes/FightWeaponFixes.js
+++ b/src/scenes/FightWeaponFixes.js
@@ -136,7 +136,7 @@ export class WeaponSystem {
     const throwChance = WeaponSystem.calculateThrowChance(fighter.weaponType, labruteWeapons);
     
     // Décision basée sur les probabilités officielles
-    const roll = rng.float();
+    const roll = rng.next();
     
     if (roll < throwChance) {
       return 'throw';


### PR DESCRIPTION
## Summary
- replace custom RNG with rand-seed wrapper exposing next()
- wire new RNG through combat formulas, pets and scenes
- add rand-seed dependency

## Testing
- `npm test`
- `node - <<'NODE'
import Rand from 'rand-seed';
import { RNG } from './src/engine/rng.js';
const seed = 12345;
const our = new RNG(seed);
const official = new Rand(seed);
console.log(Array.from({length:5}, () => our.next()));
console.log(Array.from({length:5}, () => official.next()));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68ad5d51a66483209404aa008fe278ad