### PR TITLE
feat: add parts and seed endpoints

### DIFF
--- a/meta/parts.csv
+++ b/meta/parts.csv
@@ -1,0 +1,3 @@
+id,name,description
+1,Sword,Sharp blade
+2,Shield,Protective gear

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -1,0 +1,33 @@
+import { Router } from 'express';
+import fs from 'fs';
+import path from 'path';
+
+const router = Router();
+
+router.get('/api/parts', async (_req, res) => {
+  try {
+    const csvPath = path.resolve(__dirname, '..', '..', 'meta', 'parts.csv');
+    const csvData = await fs.promises.readFile(csvPath, 'utf-8');
+    const lines = csvData.trim().split(/\r?\n/);
+    const headers = (lines.shift() || '').split(',');
+    const parts = lines.filter(Boolean).map((line) => {
+      const values = line.split(',');
+      const entry: Record<string, string> = {};
+      headers.forEach((h, i) => {
+        entry[h] = values[i];
+      });
+      return entry;
+    });
+    res.json(parts);
+  } catch (error) {
+    console.error('Failed to read parts.csv', error);
+    res.status(500).json({ error: 'Could not load parts data' });
+  }
+});
+
+router.post('/api/seed', (req, res) => {
+  const { seed } = req.body as { seed?: unknown };
+  res.json({ seed });
+});
+
+export default router;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -9,6 +9,7 @@ import fightsRouter from './routes/fights';
 import fightsTestRouter from './routes/fights-test';
 import fightsOfficialRouter from './routes/fights-official';
 import matchmakingRouter from './routes/matchmaking';
+import miscRouter from './routes';
 
 const app = express();
 app.use(cors());
@@ -42,6 +43,7 @@ app.use('/api/fights', fightsTestRouter); // Use test router for now
 app.use('/api/fights', fightsOfficialRouter); // OFFICIAL LABRUTE ENGINE
 // app.use('/api/fights', fightsRouter); // Original with DB
 app.use('/api/matchmaking', matchmakingRouter);
+app.use(miscRouter);
 
 // Serve static public/ from project root
 const rootDir = path.resolve(__dirname, '..', '..');


### PR DESCRIPTION
## Summary
- implement generic router with CSV-powered `/api/parts`
- add demo `/api/seed` POST endpoint
- wire new router into server

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build` (fails: Could not find a declaration file for module '../../../src/engine/labrute-complete.js', etc.)


------
https://chatgpt.com/codex/tasks/task_e_68ad6168fcfc8320b6283f876d85cb62