### PR TITLE
feat: add character creator hook and view

### DIFF
--- a/client/src/hooks/useCharacter.ts
+++ b/client/src/hooks/useCharacter.ts
@@ -1,0 +1,54 @@
+import { useCallback, useMemo, useState } from 'react';
+
+// Part represents a selectable character part with multiple texture options
+export type Part = {
+  /** unique name of the part */
+  name: string;
+  /** available texture options for this part */
+  textures: string[];
+};
+
+// Generate a random selection for all parts
+export const randomize = (parts: Part[]): Record<string, number> => {
+  const selection: Record<string, number> = {};
+  parts.forEach((p) => {
+    selection[p.name] = Math.floor(Math.random() * p.textures.length);
+  });
+  return selection;
+};
+
+// Get a string seed representing current selection
+export const getSeed = (selection: Record<string, number>): string => {
+  return Object.keys(selection)
+    .sort()
+    .map((key) => `${key}:${selection[key]}`)
+    .join('|');
+};
+
+// Hook handling character part selection state
+export const useCharacter = (parts: Part[]) => {
+  const [selection, setSelection] = useState<Record<string, number>>(() => randomize(parts));
+
+  // Select a specific option for a part
+  const select = useCallback((name: string, index: number) => {
+    setSelection((s) => ({ ...s, [name]: index }));
+  }, []);
+
+  // Randomize all parts
+  const randomizeAll = useCallback(() => {
+    setSelection(randomize(parts));
+  }, [parts]);
+
+  // Compute a seed from the selection
+  const seed = useMemo(() => getSeed(selection), [selection]);
+
+  return {
+    parts,
+    selection,
+    select,
+    randomize: randomizeAll,
+    seed,
+  };
+};
+
+export default useCharacter;

--- a/client/src/views/CreatorView.tsx
+++ b/client/src/views/CreatorView.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Stage, Graphics } from '@pixi/react';
+import { Part, useCharacter } from '../hooks/useCharacter';
+
+// Example parts with color placeholders
+const PARTS: Part[] = [
+  { name: 'head', textures: ['#ff0000', '#00ff00', '#0000ff'] },
+  { name: 'body', textures: ['#ffff00', '#00ffff', '#ff00ff'] },
+  { name: 'legs', textures: ['#ffffff', '#999999', '#000000'] },
+];
+
+// Helper to draw a colored square for a part
+const drawSquare = (g: PIXI.Graphics, color: string, x: number) => {
+  g.clear();
+  g.beginFill(parseInt(color.replace('#', ''), 16));
+  g.drawRect(x, 0, 100, 100);
+  g.endFill();
+};
+
+const CreatorView = () => {
+  const { selection, select, randomize } = useCharacter(PARTS);
+
+  return (
+    <div>
+      <button onClick={randomize}>Randomize</button>
+      <Stage width={PARTS.length * 120} height={120} options={{ backgroundAlpha: 0 }}>
+        {PARTS.map((part, i) => (
+          <Graphics
+            key={part.name}
+            draw={(g) => drawSquare(g, part.textures[selection[part.name]], i * 120)}
+            eventMode="static"
+            pointerdown={() => select(part.name, (selection[part.name] + 1) % part.textures.length)}
+          />
+        ))}
+      </Stage>
+    </div>
+  );
+};
+
+export default CreatorView;


### PR DESCRIPTION
## Summary
- add `useCharacter` hook with randomize and seed helpers
- add `CreatorView` leveraging `@pixi/react` Stage and hook to select character parts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad6166bed08320ab6ffe42793c6ce3