### PR TITLE
refactor: unify StepType enumeration to string constants

### DIFF
--- a/server/combat/LaBruteEngine.js
+++ b/server/combat/LaBruteEngine.js
@@ -12,44 +12,8 @@
  */
 
 // ===== TYPES DE STEPS OFFICIELS =====
-const StepType = {
-  Saboteur: 0,
-  Leave: 1,
-  Arrive: 2,
-  Trash: 3,
-  Steal: 4,
-  Trap: 5,
-  Heal: 6,
-  Resist: 7,
-  Survive: 8,
-  Hit: 9,
-  FlashFlood: 10,
-  Hammer: 11,
-  Poison: 12,
-  Bomb: 13,
-  Hypnotise: 14,
-  Move: 15,
-  Eat: 16,
-  MoveBack: 17,
-  Equip: 18,
-  AttemptHit: 19,
-  Block: 20,
-  Evade: 21,
-  Sabotage: 22,
-  Disarm: 23,
-  Death: 24,
-  Throw: 25,
-  End: 26,
-  Counter: 27,
-  SkillActivate: 28,
-  SkillExpire: 29,
-  Spy: 30,
-  Vampirism: 31,
-  Haste: 32,
-  Treat: 33,
-  DropShield: 34,
-  Regeneration: 35
-};
+// Utilise l'énumération commune basée sur des chaînes pour éviter les divergences
+const { StepType } = require('../engine/labrute-core/constants');
 
 // ===== ARMES OFFICIELLES AVEC VRAIES STATS =====
 const WeaponData = {

--- a/server/combat/LaBruteEngine.test.mjs
+++ b/server/combat/LaBruteEngine.test.mjs
@@ -1,7 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import EngineModule from './LaBruteEngine.js';
-const { LaBruteEngine, StepType } = EngineModule;
+import constants from '../engine/labrute-core/constants.js';
+const { LaBruteEngine } = EngineModule;
+const { StepType } = constants;
 
 function baseBrute(overrides = {}) {
   return {

--- a/server/engine/labrute-core/constants.js
+++ b/server/engine/labrute-core/constants.js
@@ -20,6 +20,7 @@ const StepType = {
   Saboteur: 'saboteur',
   SkillActivate: 'skillActivate',
   SkillExpire: 'skillExpire',
+  Spy: 'spy',
   Trap: 'trap',
   Bomb: 'bomb',
   Hammer: 'hammer',


### PR DESCRIPTION
## Summary
- use shared string StepType enum in `LaBruteEngine`
- add missing `Spy` step type to constants
- update engine tests to import StepType from central constants

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad778e37c48320add42ad3bbef7c6c