### PR TITLE
feat: toggle custom combat moves with flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ The project requires the following script libraries:
 
 You can add your script nodes to the `src/script-nodes` folder.
 
+## Mode de combats personnalisés
+
+Le constructeur de `CombatEngine` accepte un drapeau `enableCustomMoves`.
+Lorsqu'il est activé, le moteur charge des coups spéciaux additionnels qui
+modifient le déroulement des combats (Berserker Rage, Defensive Shield, etc.).
+Ce mode est **désactivé par défaut** afin de rester fidèle au comportement du
+jeu original.
+
 ## Join the Phaser Community!
 
 We love to see what developers like you create with Phaser! It really motivates us to keep improving. So please join our community and show off your work 😄

--- a/src/engine/CombatEngine.js
+++ b/src/engine/CombatEngine.js
@@ -80,9 +80,22 @@ export class CombatEngine {
     
     // Initialize pets if fighters have them
     this.initializePets();
-    
-    // Initialize special moves for both fighters
-    this.initializeSpecialMoves();
+
+    // Flag to enable custom special moves (disabled by default)
+    this.enableCustomMoves = Boolean(options.enableCustomMoves);
+
+    if (this.enableCustomMoves) {
+      // Initialize special moves for both fighters
+      this.initializeSpecialMoves();
+    } else {
+      // Ensure structure exists but skip custom moves to match original behavior
+      this.specialMoves = {};
+      [this.fighter1, this.fighter2].forEach(fighter => {
+        fighter.specialMoves = { unlocked: [], active: {} };
+      });
+      // Still calculate initiative even when special moves are disabled
+      this.calculateInitiative();
+    }
   }
   
   initializePets() {


### PR DESCRIPTION
## Summary
- add `enableCustomMoves` option to `CombatEngine` to conditionally initialize experimental special moves
- document the flag and its default disabled behavior in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad7e6d081c8320bd81e7c4e5eda200