### PR TITLE
Align accuracy formula with official engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "build": "vite build --config vite/config.prod.mjs && phaser-asset-pack-hashing -j -r dist",
         "test": "npm run test:engine && npm run test:combat",
         "sync:labrute": "node scripts/sync-labrute-data.mjs",
-        "test:engine": "node --test server/combat/LaBruteEngine.test.mjs",
+        "test:engine": "node --test server/combat/LaBruteEngine.test.mjs src/engine/formulas.test.mjs",
         "test:combat": "node scripts/runCombatTest.mjs",
         "test:combat:snap": "node scripts/runCombatTest.mjs --snapshot --seed=42",
         "test:combat:debug": "node scripts/runCombatTest.mjs --debug --seed=42",

--- a/src/engine/formulas.js
+++ b/src/engine/formulas.js
@@ -130,26 +130,25 @@ export function computeDodgeChance(stats) {
  * Accuracy base and weapon modifiers
  */
 export function computeAccuracy(attackerStats, weaponType) {
-  // Try LaBrute weapons first
+  // Official LaBrute logic:
+  // - Fighters have a base 90% chance to hit
+  // - Each weapon adds its accuracy as a percentage bonus
+  // - Missing accuracy data on a weapon means no additional bonus (0)
+  // - Final hit chance is capped at 98%
+  let acc = 0.90; // base 90%
+
+  // Try LaBrute weapons first for official accuracy bonuses
   const labruteWeapon = LABRUTE_WEAPONS[weaponType];
-  let weaponAcc = 0.75; // Default accuracy
-  
-  if (labruteWeapon) {
-    // LaBrute weapons have different accuracy system, many have 0
-    // Convert to reasonable accuracy values
-    if (labruteWeapon.accuracy !== undefined && labruteWeapon.accuracy > 0) {
-      weaponAcc = labruteWeapon.accuracy / 100; // Convert to percentage
-    } else {
-      // Default accuracy for LaBrute weapons without specific accuracy
-      weaponAcc = 0.85; // Good default hit chance
-    }
+  if (labruteWeapon && typeof labruteWeapon.accuracy === 'number') {
+    acc += labruteWeapon.accuracy * 0.01; // convert bonus from 0-100 to 0-1
   } else if (weaponType && weaponStats[weaponType] && typeof weaponStats[weaponType].accuracy === 'number') {
-    weaponAcc = weaponStats[weaponType].accuracy;
+    // Our custom weapons use direct accuracy values
+    acc = weaponStats[weaponType].accuracy;
   }
-  
+
   const agg = aggregateFromSkills(attackerStats && attackerStats.skills);
   const bonus = (attackerStats.accuracyBonus || 0) + (agg.accuracy || 0);
-  return clamp01(weaponAcc + bonus);
+  return Math.min(0.98, acc + bonus); // official cap
 }
 
 /**

--- a/src/engine/formulas.test.mjs
+++ b/src/engine/formulas.test.mjs
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { computeAccuracy } from './formulas.js';
+import { LABRUTE_WEAPONS } from './labrute-complete.js';
+
+function officialAccuracy(weapon) {
+  const base = 0.90;
+  const bonus = (LABRUTE_WEAPONS[weapon]?.accuracy || 0) * 0.01;
+  return Math.min(0.98, base + bonus);
+}
+
+test('knife uses only base accuracy (90%)', () => {
+  const res = computeAccuracy({}, 'knife');
+  assert.equal(res, officialAccuracy('knife'));
+});
+
+test('sai adds weapon accuracy bonus and caps at 98%', () => {
+  const res = computeAccuracy({}, 'sai');
+  assert.equal(res, officialAccuracy('sai'));
+});


### PR DESCRIPTION
## Summary
- adopt official hit chance: 90% base plus weapon bonus capped at 98%
- document accuracy logic and remove placeholder 85% default
- add unit tests verifying accuracy matches official engine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad83bf0c20832099fea7421201116d