### PR TITLE
feat(engine): apply skill damage modifiers

### DIFF
--- a/src/config/enums.js
+++ b/src/config/enums.js
@@ -1,0 +1,33 @@
+import constants from '../../server/engine/labrute-official/constants.js';
+
+export const { SkillName, WeaponName, PetName } = constants;
+
+export const StepType = {
+  Init: 'init',
+  Move: 'move',
+  MoveBack: 'moveBack',
+  Hit: 'hit',
+  Miss: 'miss',
+  Block: 'block',
+  Evade: 'evade',
+  Counter: 'counter',
+  Throw: 'throw',
+  Heal: 'heal',
+  Death: 'death',
+  End: 'end',
+  Hammer: 'hammer',
+  Poison: 'poison',
+  FlashFlood: 'flashFlood',
+  Bomb: 'bomb',
+  Vampirism: 'vampirism',
+  Haste: 'haste',
+  Resist: 'resist',
+  Survive: 'survive',
+  Skill: 'skill',
+  Equip: 'equip',
+  Saboteur: 'saboteur',
+  Disarm: 'disarm',
+  Steal: 'steal',
+  Trap: 'trap',
+  NetTrap: 'netTrap',
+};


### PR DESCRIPTION
## Summary
- add SkillDamageModifiers table and apply fighter/opponent multipliers in authentic engine
- expose enums for client engine
- test piledriver and leadSkeleton damage cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad835ad10c8320a9a447545755aeb5