### PR TITLE
Add boss selection and reward logic

### DIFF
--- a/server/combat/bosses.js
+++ b/server/combat/bosses.js
@@ -1,0 +1,83 @@
+const bosses = [
+  {
+    id: 'goldclaw',
+    name: 'GoldClaw',
+    base: 'bear',
+    scale: 2,
+    initiative: -0.5,
+    strength: 400,
+    agility: 2,
+    speed: 1,
+    hp: 100000,
+    counter: 0,
+    combo: -0.2,
+    block: -0.25,
+    evasion: 0.1,
+    accuracy: 0.75,
+    disarm: 0.05,
+    damage: 5,
+    reach: 3,
+    count: 1,
+    reward: 1,
+    odds: 10,
+  },
+  {
+    id: 'emberfang',
+    name: 'EmberFang',
+    base: 'panther',
+    scale: 3,
+    initiative: -0.5,
+    strength: 46,
+    agility: 16,
+    speed: 240,
+    hp: 50000,
+    counter: 0,
+    combo: 0.7,
+    block: 0,
+    evasion: 0.2,
+    accuracy: 0.75,
+    disarm: 0,
+    damage: 3,
+    reach: 3,
+    count: 1,
+    reward: 1,
+    odds: 10,
+  },
+  {
+    id: 'cerberus',
+    name: 'Cerberus',
+    base: 'dog',
+    scale: 2.15,
+    initiative: 1.3,
+    strength: 45,
+    agility: 5,
+    speed: 3.6,
+    hp: 10000,
+    counter: 0,
+    combo: 0,
+    block: 0,
+    evasion: -0.2,
+    accuracy: 0.75,
+    disarm: 0,
+    damage: 3,
+    reach: 1,
+    count: 3,
+    reward: 0.2,
+    odds: 1,
+  },
+];
+
+function selectBoss() {
+  const totalOdds = bosses.reduce((sum, b) => sum + b.odds, 0);
+  const roll = Math.random() * totalOdds;
+  let acc = 0;
+  for (const boss of bosses) {
+    acc += boss.odds;
+    if (roll < acc) {
+      return { ...boss };
+    }
+  }
+  return { ...bosses[0] };
+}
+
+module.exports = { bosses, selectBoss };

--- a/server/combat/generateFight.js
+++ b/server/combat/generateFight.js
@@ -1,8 +1,10 @@
 const FightManager = require('./FightManager');
 const { randomItem } = require('../engine/labrute-core/constants');
+const { selectBoss } = require('./bosses');
 
-// Simple constant for boss gold reward
-const BOSS_GOLD_REWARD = 1000;
+// Boss rewards constants
+const BOSS_GOLD_REWARD = 500;
+const BOSS_XP_REWARD = 500;
 
 // Select a single backup from a list
 const selectBackup = (backups) => {
@@ -51,6 +53,14 @@ const generateFight = ({
   const team1Backups = backups ? selectBackup(team1.backups) : null;
   const team2Backups = backups ? selectBackup(team2.backups) : null;
 
+  // Boss selection
+  if (team1.bosses === true) {
+    team1.bosses = [selectBoss()];
+  }
+  if (team2.bosses === true) {
+    team2.bosses = [selectBoss()];
+  }
+
   // Bosses
   const team1Bosses = expandBosses(team1.bosses);
   const team2Bosses = expandBosses(team2.bosses);
@@ -85,10 +95,17 @@ const generateFight = ({
   let bossReward;
 
   if (team1Bosses.length || team2Bosses.length) {
-    const bossDefeated = fightResult.winner === brute1.name && team2Bosses.length > 0;
-    const gold = bossDefeated ? BOSS_GOLD_REWARD : 0;
-    bossReward = { defeated: bossDefeated, xp: 0, gold };
+    const bossSide = team1Bosses.length ? 'team1' : 'team2';
+    const boss = team1Bosses.length ? team1.bosses[0] : team2.bosses[0];
+    const bossDefeated = bossSide === 'team2'
+      ? fightResult.winner === brute1.name
+      : fightResult.winner === brute2.name;
+    const rewardMultiplier = boss && boss.reward ? boss.reward : 1;
+    const gold = bossDefeated ? Math.floor(rewardMultiplier * BOSS_GOLD_REWARD) : 0;
+    const xp = bossDefeated ? Math.floor(rewardMultiplier * BOSS_XP_REWARD) : 0;
+    bossReward = { defeated: bossDefeated, xp, gold };
     rewards.gold += gold;
+    rewards.xp += xp;
   }
 
   if (clanWar && fightResult.winner === brute1.name) {
@@ -114,4 +131,4 @@ const generateFight = ({
   };
 };
 
-module.exports = { generateFight, BOSS_GOLD_REWARD };
+module.exports = { generateFight, BOSS_GOLD_REWARD, BOSS_XP_REWARD };

--- a/server/combat/generateFight.test.js
+++ b/server/combat/generateFight.test.js
@@ -1,6 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert');
-const { generateFight, BOSS_GOLD_REWARD } = require('./generateFight');
+const { generateFight, BOSS_GOLD_REWARD, BOSS_XP_REWARD } = require('./generateFight');
 
 test('achievements store tracks wins and losses', () => {
   const team1 = { brutes: [{ id: 'a', name: 'A', strength: 100, hp: 100 }] };
@@ -27,14 +27,13 @@ test('handles boss fights and rewards gold', () => {
   const seq = [0.1, 0.2, 0.3, 0.4, 0.5];
   let i = 0;
   Math.random = () => { const r = seq[i % seq.length]; i += 1; return r; };
-  const team1 = { brutes: [{ id: 'a', name: 'A', strength: 100, hp: 100 }] };
-  const team2 = {
-    bosses: [{ id: 'boss1', name: 'Boss', hp: 30, level: 1, count: 2 }],
-  };
+  const team1 = { brutes: [{ id: 'a', name: 'A', strength: 1000000, hp: 1000000 }] };
+  const team2 = { bosses: true };
   try {
     const result = generateFight({ team1, team2 });
     assert.strictEqual(result.boss.defeated, true);
     assert.strictEqual(result.boss.gold, BOSS_GOLD_REWARD);
+    assert.strictEqual(result.boss.xp, BOSS_XP_REWARD);
   } finally {
     Math.random = originalRandom;
   }


### PR DESCRIPTION
## Summary
- Add server-side boss stats and weighted selection
- Integrate boss choice and rewards (gold/xp) in fight generation
- Update tests for boss selection and rewards

## Testing
- `node server/combat/generateFight.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad8c387bc883209a2f83ed18fc9e77