### PR TITLE
Use official weapon stats across engine and tests

### DIFF
--- a/scripts/test-labrute-integration.js
+++ b/scripts/test-labrute-integration.js
@@ -2,18 +2,18 @@
 // 🧪 SCRIPT DE TEST - SYSTÈME LABRUTE COMPLET
 // ================================================
 
-import { 
+import {
   LaBruteCombatEngine,
   LaBruteLevelSystem,
   LaBruteTournament,
   LaBruteDestinyTree,
   LaBrutePupilSystem,
   LaBruteCombatFormulas,
-  LABRUTE_WEAPONS,
-  LABRUTE_SKILLS,
   LABRUTE_PETS,
   LABRUTE_CONFIG
 } from '../src/engine/labrute-complete.js';
+import { LABRUTE_WEAPONS } from '../src/game/labrute-weapons.js';
+import { LABRUTE_SKILLS } from '../src/game/labrute-skills.js';
 
 console.log('================================================');
 console.log('🎮 TEST DU SYSTÈME LABRUTE COMPLET');
@@ -26,16 +26,16 @@ console.log('================================================\n');
 console.log('📋 TEST 1: VÉRIFICATION DES DONNÉES');
 console.log('------------------------------------');
 
-console.log(`✅ Nombre d'armes: ${Object.keys(LABRUTE_WEAPONS).length} (attendu: 28)`);
-console.log(`✅ Nombre de skills: ${Object.keys(LABRUTE_SKILLS).length} (attendu: 30)`);
+console.log(`✅ Nombre d'armes: ${Object.keys(LABRUTE_WEAPONS).length} (attendu: 26)`);
+console.log(`✅ Nombre de skills: ${Object.keys(LABRUTE_SKILLS).length} (attendu: 50)`);
 console.log(`✅ Nombre de pets: ${Object.keys(LABRUTE_PETS).length} (attendu: 3)`);
 console.log(`✅ Niveau max: ${LABRUTE_CONFIG.MAX_LEVEL} (attendu: 80)`);
 
 // Vérifier quelques armes spécifiques
 console.log('\n🗡️ Vérification armes spéciales:');
-console.log(`- Poireau (100% précision): ${LABRUTE_WEAPONS.leek.accuracy === 100 ? '✅' : '❌'}`);
-console.log(`- Fléau (ignore esquive/parade): ${LABRUTE_WEAPONS.flail.accuracy === 100 ? '✅' : '❌'}`);
-console.log(`- Marteau de pierre (20 dégâts): ${LABRUTE_WEAPONS.stoneHammer.damage === 20 ? '✅' : '❌'}`);
+console.log(`- Poireau (bonus précision 2): ${LABRUTE_WEAPONS.leek.accuracy === 2 ? '✅' : '❌'}`);
+console.log(`- Fléau (bonus précision 1.5): ${LABRUTE_WEAPONS.flail.accuracy === 1.5 ? '✅' : '❌'}`);
+console.log(`- Hache (55 dégâts): ${LABRUTE_WEAPONS.axe.damage === 55 ? '✅' : '❌'}`);
 
 // ================================================
 // TEST 2: SYSTÈME DE NIVEAUX

--- a/server/src/routes/brutes.ts
+++ b/server/src/routes/brutes.ts
@@ -4,10 +4,10 @@ import prisma from '../lib/prisma';
 import { requireAuth, AuthRequest } from '../middleware/auth';
 import {
   LaBruteLevelSystem,
-  LABRUTE_WEAPONS,
   LABRUTE_SKILLS,
   LABRUTE_PETS
 } from '../../../src/engine/labrute-complete.js';
+import { LABRUTE_WEAPONS } from '../../../src/game/labrute-weapons.js';
 import { getRandomBonus, getLevelUpChoices } from '../../../src/game/leveling.js';
 
 const router = Router();

--- a/src/engine/CombatEngine.js
+++ b/src/engine/CombatEngine.js
@@ -6,10 +6,9 @@ import { RNG } from './rng.js';
 import formulas from './formulas.js';
 
 // Import du système LaBrute complet
-import { 
-  LaBruteCombatEngine, 
+import {
+  LaBruteCombatEngine,
   LaBruteCombatFormulas,
-  LABRUTE_WEAPONS,
   LABRUTE_SKILLS,
   LABRUTE_PETS,
   LABRUTE_CONFIG

--- a/src/engine/formulas.js
+++ b/src/engine/formulas.js
@@ -4,7 +4,7 @@
 
 import { weaponStats } from '../game/weapons.js';
 import { SkillModifiers, FightStat } from '../game/skills.js';
-import { LABRUTE_WEAPONS } from './labrute-complete.js';
+import { LABRUTE_WEAPONS } from '../game/labrute-weapons.js';
 
 // Utility: clamp value to [0, 0.99]
 function clamp01(v) {
@@ -153,10 +153,8 @@ export function computeAccuracy(attackerStats, weaponType) {
 
 /**
  * Base damage from strength + weapon modifier (or fists boost)
- * Using official LaBrute weapon damage values
- * FORMULE OFFICIELLE LABRUTE:
- * - Avec arme: damage = (weapon_damage / 10) + strength
- * - Sans arme: damage = strength
+ * Using official LaBrute weapon damage values already normalized
+ * according to the official formula.
  */
 export function computeBaseDamage(attackerStats, hasWeapon, weaponType) {
   const adjusted = getAdjustedStats(attackerStats);

--- a/src/engine/formulas.test.mjs
+++ b/src/engine/formulas.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { computeAccuracy } from './formulas.js';
-import { LABRUTE_WEAPONS } from './labrute-complete.js';
+import { LABRUTE_WEAPONS } from '../game/labrute-weapons.js';
 
 function officialAccuracy(weapon) {
   const base = 0.90;
@@ -14,7 +14,7 @@ test('knife uses only base accuracy (90%)', () => {
   assert.equal(res, officialAccuracy('knife'));
 });
 
-test('sai adds weapon accuracy bonus and caps at 98%', () => {
-  const res = computeAccuracy({}, 'sai');
-  assert.equal(res, officialAccuracy('sai'));
+test('leek adds weapon accuracy bonus', () => {
+  const res = computeAccuracy({}, 'leek');
+  assert.equal(res, officialAccuracy('leek'));
 });


### PR DESCRIPTION
## Summary
- load official weapon data in formula calculations
- adjust accuracy tests and integration script for official stats
- serve weapon list using official dataset

## Testing
- `node src/engine/formulas.test.mjs`
- `node scripts/test-labrute-integration.js > /tmp/integration.log && head -n 20 /tmp/integration.log`


------
https://chatgpt.com/codex/tasks/task_e_68ad8c35292483209350d944808f1ec3