### PR TITLE
Use rand-seed for deterministic RNG

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "@phaserjs/editor-scripts-base": "^1.0.0",
                 "cors": "^2.8.5",
                 "phaser": "3.80.1",
+                "rand-seed": "^3.0.0",
                 "socket.io": "^4.8.1"
             },
             "devDependencies": {
@@ -2564,6 +2565,12 @@
             "engines": {
                 "node": ">=0.6"
             }
+        },
+        "node_modules/rand-seed": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/rand-seed/-/rand-seed-3.0.0.tgz",
+            "integrity": "sha512-Zy8wnL6whyIAGOX2i9Mn1Orq3t9TNizGUk8euxamr60Z3PmspwFeT+vCZPcYMAR5nOztnAKPtVi3jt8EzmCB6g==",
+            "license": "MIT"
         },
         "node_modules/readable-stream": {
             "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "@phaserjs/editor-scripts-base": "^1.0.0",
         "cors": "^2.8.5",
         "phaser": "3.80.1",
+        "rand-seed": "^3.0.0",
         "socket.io": "^4.8.1"
     }
 }

--- a/server/combat/LaBruteEngine.test.mjs
+++ b/server/combat/LaBruteEngine.test.mjs
@@ -75,7 +75,7 @@ test('generates trap step with skill', () => {
 test('getDamage applies piledriver multiplier', () => {
   const engine = new LaBruteAuthenticEngine();
   const rolls = [0, 1];
-  engine.random = () => rolls.shift();
+  engine.random = { next: () => rolls.shift() };
   const attacker = engine.createDetailedFighter({ strength: 10, agility: 10 }, 0, 'L');
   const defender = engine.createDetailedFighter({ strength: 10, agility: 10 }, 1, 'R');
   attacker.activeSkills = [{ name: SkillName.hammer }];
@@ -85,7 +85,7 @@ test('getDamage applies piledriver multiplier', () => {
 
 test('getDamage reduced by leadSkeleton', () => {
   const engine = new LaBruteAuthenticEngine();
-  const makeRandom = () => { const rolls = [0, 1]; return () => rolls.shift(); };
+  const makeRandom = () => { const rolls = [0, 1]; return { next: () => rolls.shift() }; };
   const attacker = engine.createDetailedFighter({ strength: 10, agility: 10 }, 0, 'L');
   attacker.activeWeapon = { name: 'sword', damage: 5, types: ['melee'] };
 

--- a/server/src/routes/fights-test.ts
+++ b/server/src/routes/fights-test.ts
@@ -1,17 +1,6 @@
 import { Router } from 'express';
 import { LaBruteEngine } from '../../combat/LaBruteEngine.js';
-
-// Simple deterministic RNG (Mulberry32)
-function createSeededRandom(seed: number) {
-  let a = seed >>> 0;
-  return () => {
-    a += 0x6D2B79F5;
-    let t = a;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
+import Rand from 'rand-seed';
 
 const router = Router();
 
@@ -98,7 +87,8 @@ router.post('/test', async (req: any, res) => {
     console.log(`   - Seed utilisé: ${seed}`);
 
     // UTILISATION DU VRAI MOTEUR LABRUTE avec RNG seedé
-    const engine = new LaBruteEngine(createSeededRandom(seed));
+    const rand = new Rand(seed);
+    const engine = new LaBruteEngine(rand.next.bind(rand));
     const combatResult = engine.generateFight(brute1, brute2);
     
     // Structure de réponse compatible avec le client

--- a/src/engine/LaBruteAuthenticEngine.js
+++ b/src/engine/LaBruteAuthenticEngine.js
@@ -7,6 +7,7 @@
  */
 
 import constants from '../../server/engine/labrute-core/constants.js';
+import Rand from 'rand-seed';
 const { SkillName, WeaponName, PetName, StepType } = constants;
 
 // Modificateurs de dégâts liés aux compétences
@@ -40,25 +41,12 @@ export class LaBruteAuthenticEngine {
    */
   initialize(seed = Date.now()) {
     this.seed = seed;
-    this.random = this.createSeededRandom(seed);
+    this.random = new Rand(seed);
     this.steps = [];
     this.initiative = 0;
     this.turn = 0;
   }
 
-  /**
-   * Générateur de nombres aléatoires avec seed (Mulberry32)
-   */
-  createSeededRandom(seed) {
-    let state = seed;
-    return () => {
-      state |= 0;
-      state = state + 0x6D2B79F5 | 0;
-      let t = Math.imul(state ^ state >>> 15, 1 | state);
-      t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
-      return ((t ^ t >>> 14) >>> 0) / 4294967296;
-    };
-  }
 
   /**
    * Configure les combattants
@@ -206,17 +194,17 @@ export class LaBruteAuthenticEngine {
     if (thrown) {
       damage = Math.floor(
         (base + attacker.strength * 0.1 + attacker.agility * 0.15)
-        * (1 + this.random() * 0.5) * skillsMultiplier
+        * (1 + this.random.next() * 0.5) * skillsMultiplier
       );
     } else if (piledriver) {
       damage = Math.floor(
         (10 + defender.strength * 0.6)
-        * (0.8 + this.random() * 0.4) * skillsMultiplier
+        * (0.8 + this.random.next() * 0.4) * skillsMultiplier
       );
     } else {
       damage = Math.floor(
         (base + attacker.strength * (0.2 + base * 0.05))
-        * (0.8 + this.random() * 0.4) * skillsMultiplier
+        * (0.8 + this.random.next() * 0.4) * skillsMultiplier
       );
     }
 
@@ -227,7 +215,7 @@ export class LaBruteAuthenticEngine {
 
     // Coup critique (5% de base)
     const criticalChance = 0.05;
-    const criticalHit = this.random() < criticalChance;
+    const criticalHit = this.random.next() < criticalChance;
     if (criticalHit) {
       damage = Math.floor(damage * 2);
     }
@@ -249,8 +237,8 @@ export class LaBruteAuthenticEngine {
    * Détermine qui joue en premier
    */
   determineFirstFighter() {
-    const f1Initiative = this.fighters[0].initiative + this.random() * 10;
-    const f2Initiative = this.fighters[1].initiative + this.random() * 10;
+    const f1Initiative = this.fighters[0].initiative + this.random.next() * 10;
+    const f2Initiative = this.fighters[1].initiative + this.random.next() * 10;
     
     if (f1Initiative > f2Initiative) {
       this.fighters[0].initiative = 0;

--- a/src/engine/rng.js
+++ b/src/engine/rng.js
@@ -1,60 +1,36 @@
-// Seedable RNG utility for deterministic combat simulations
-// Mulberry32 PRNG with xmur3 hashing for string seeds
-
-function xmur3(str) {
-  let h = 1779033703 ^ str.length;
-  for (let i = 0; i < str.length; i++) {
-    h = Math.imul(h ^ str.charCodeAt(i), 3432918353);
-    h = (h << 13) | (h >>> 19);
-  }
-  return function () {
-    h = Math.imul(h ^ (h >>> 16), 2246822507);
-    h = Math.imul(h ^ (h >>> 13), 3266489909);
-    h ^= h >>> 16;
-    return h >>> 0;
-  };
-}
+// Seedable RNG utility using rand-seed for deterministic combat simulations
+import Rand from 'rand-seed';
 
 export class RNG {
   constructor(seed = Date.now()) {
     this.setSeed(seed);
   }
 
-  setSeed(seed) {
-    let n;
-    if (typeof seed === 'string') {
-      const hash = xmur3(seed);
-      n = hash();
-    } else if (typeof seed === 'number') {
-      n = seed >>> 0;
-    } else {
-      n = Date.now() >>> 0;
-    }
-    if (n === 0) n = 0x9e3779b9; // avoid zero seed
-    this._state = n >>> 0;
+  setSeed(seed = Date.now()) {
+    this.rand = new Rand(seed);
   }
 
-  // Mulberry32 step, returns float in [0,1)
+  // Alias used by some consumers expecting rng.random()
+  random() {
+    return this.rand.next();
+  }
+
+  // Float in [0,1)
   float() {
-    let t = (this._state += 0x6D2B79F5);
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    const result = ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-    this._state = this._state >>> 0;
-    return result;
+    return this.random();
   }
 
   // Integer in [min, max] inclusive
   int(min, max) {
     if (max < min) [min, max] = [max, min];
-    const r = this.float();
-    return Math.floor(r * (max - min + 1)) + min;
+    return Math.floor(this.random() * (max - min + 1)) + min;
   }
 
   // Returns true with probability p (0..1)
   chance(p) {
     if (p <= 0) return false;
     if (p >= 1) return true;
-    return this.float() < p;
+    return this.random() < p;
   }
 }
+


### PR DESCRIPTION
## Summary
- replace custom RNG with rand-seed in engines and server route
- switch random calls to rand.next() ensuring deterministic seeding
- adjust tests and server route to use Rand for random numbers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad8c6c1f8c8320aa98995b372767bc