### PR TITLE
feat: expand authentic engine skill handling

### DIFF
--- a/src/engine/LaBruteAuthenticEngine.js
+++ b/src/engine/LaBruteAuthenticEngine.js
@@ -6,24 +6,9 @@
  * server implementation is authoritative.
  */
 
-import constants from '../../server/engine/labrute-core/constants.js';
+import constants from './labrute-core/constants.js';
+import { LABRUTE_SKILLS } from './labrute-complete.js';
 const { SkillName, WeaponName, PetName, StepType } = constants;
-
-// Modificateurs de dégâts liés aux compétences
-const SkillDamageModifiers = [
-  { skill: SkillName.herculeanStrength, percent: 0.5, opponent: false },
-  { skill: SkillName.weaponsMaster, percent: 0.5, opponent: false, weaponType: 'any' },
-  { skill: SkillName.martialArts, percent: 1.0, opponent: false, weaponType: null },
-  { skill: SkillName.fierceBrute, percent: 0, opponent: false },
-  { skill: SkillName.hammer, percent: 0, opponent: false },
-  { skill: SkillName.armor, percent: -0.25, opponent: true },
-  { skill: SkillName.toughenedSkin, percent: -0.1, opponent: true },
-  { skill: SkillName.leadSkeleton, percent: -0.5, opponent: true, weaponType: 'melee' },
-  { skill: SkillName.resistant, percent: -0.15, opponent: true },
-  { skill: SkillName.saboteur, percent: 0.3, opponent: false, weaponType: 'thrown' },
-  { skill: SkillName.bodybuilder, percent: 0.4, opponent: false, weaponType: 'heavy' },
-  { skill: SkillName.relentless, percent: 0.35, opponent: false, weaponType: 'fast' },
-];
 
 export class LaBruteAuthenticEngine {
   constructor() {
@@ -76,28 +61,40 @@ export class LaBruteAuthenticEngine {
    */
   createDetailedFighter(stats, index, team) {
     // Formule officielle: HP = 50 + (endurance × 6)
-    const maxHp = 50 + (stats.endurance || 10) * 6;
-    
-    return {
+    const baseHp = 50 + (stats.endurance || 10) * 6;
+
+    const fighter = {
       index,
       team,
       name: stats.name || `Fighter ${index + 1}`,
-      hp: maxHp,
-      maxHp,
-      currentHp: maxHp,
+      hp: baseHp,
+      maxHp: baseHp,
+      currentHp: baseHp,
       strength: stats.strength || 10,
       agility: stats.agility || 10,
       speed: stats.speed || 10,
       endurance: stats.endurance || 10,
-      // Formule initiative: agility × 0.6 + speed × 0.4
-      initiative: (stats.agility || 10) * 0.6 + (stats.speed || 10) * 0.4,
+      // Formule initiative: calculée après application des compétences
+      initiative: 0,
       skills: stats.skills || [],
       weapons: stats.weapons || [],
       activeWeapon: null,
       pets: stats.pets || [],
-      armor: 0, // Calculé selon les compétences
+      armor: 0, // réduction de dégâts en pourcentage
       damage: 5, // Dégâts de base sans arme
       baseDamage: 5,
+      // Statistiques additionnelles influencées par les compétences
+      block: 0,
+      dodge: 0,
+      counter: 0,
+      comboChance: 0,
+      maxCombo: 1,
+      critChance: 0.05,
+      accuracy: 0,
+      incomingDamageMultiplier: 1,
+      meleeWeaponMultiplier: 1,
+      weaponDamageMultiplier: 1,
+      bareHandsDamageMultiplier: 1,
       stunned: false,
       trapped: false,
       immune: false,
@@ -106,6 +103,149 @@ export class LaBruteAuthenticEngine {
       activeSkills: [],
       damagedWeapons: []
     };
+
+    // Appliquer les modifications des compétences
+    this.applySkillModifiers(fighter);
+
+    // Recalculer l'initiative après application des compétences
+    fighter.initiative = fighter.agility * 0.6 + fighter.speed * 0.4;
+
+    // HP et dégâts après modifications
+    fighter.maxHp = Math.floor(fighter.maxHp);
+    fighter.hp = fighter.currentHp = fighter.maxHp;
+    fighter.baseDamage = Math.floor(fighter.baseDamage * fighter.bareHandsDamageMultiplier);
+    fighter.damage = fighter.baseDamage;
+
+    return fighter;
+  }
+
+  /**
+   * Applique les modificateurs des compétences sur un combattant
+   */
+  applySkillModifiers(fighter) {
+    const applyStat = (stat, mod) => {
+      if (typeof fighter[stat] === 'undefined') {
+        fighter[stat] = 0;
+      }
+      if (mod.multiply !== undefined) {
+        fighter[stat] *= mod.multiply;
+      }
+      if (mod.add !== undefined) {
+        fighter[stat] += mod.add;
+      }
+    };
+
+    fighter.skills.forEach((sk) => {
+      const name = typeof sk === 'string' ? sk : sk.name;
+      const data = LABRUTE_SKILLS[name];
+      if (!data || !data.modifiers) { return; }
+
+      for (const [key, mod] of Object.entries(data.modifiers)) {
+        switch (key) {
+          case 'strength':
+          case 'agility':
+          case 'speed':
+            applyStat(key, mod);
+            break;
+          case 'hp':
+            applyStat('maxHp', mod);
+            break;
+          case 'bareHandsDamage':
+            if (mod.multiply !== undefined) {
+              fighter.bareHandsDamageMultiplier *= mod.multiply;
+            }
+            if (mod.add !== undefined) {
+              fighter.baseDamage += mod.add;
+            }
+            break;
+          case 'weaponDamage':
+            if (mod.multiply !== undefined) {
+              fighter.weaponDamageMultiplier *= mod.multiply;
+            }
+            break;
+          case 'block':
+            if (mod.multiply !== undefined) {
+              fighter.block *= mod.multiply;
+            }
+            if (mod.add !== undefined) {
+              fighter.block += mod.add / 100;
+            }
+            break;
+          case 'armor':
+            if (mod.multiply !== undefined) {
+              fighter.armor *= mod.multiply;
+            }
+            if (mod.add !== undefined) {
+              fighter.armor += (mod.add / 100);
+            }
+            break;
+          case 'damageReduction':
+            if (mod.multiply !== undefined) {
+              fighter.incomingDamageMultiplier *= mod.multiply;
+            }
+            if (mod.add !== undefined) {
+              fighter.incomingDamageMultiplier *= (1 - mod.add / 100);
+            }
+            break;
+          case 'dodge':
+            if (mod.multiply !== undefined) {
+              fighter.dodge *= mod.multiply;
+            }
+            if (mod.add !== undefined) {
+              fighter.dodge += mod.add / 100;
+            }
+            break;
+          case 'heavyWeaponReduction':
+            if (mod.multiply !== undefined) {
+              fighter.meleeWeaponMultiplier *= mod.multiply;
+            }
+            if (mod.add !== undefined) {
+              fighter.meleeWeaponMultiplier *= (1 - mod.add / 100);
+            }
+            break;
+          case 'counter':
+            if (mod.multiply !== undefined) {
+              fighter.counter *= mod.multiply;
+            }
+            if (mod.add !== undefined) {
+              fighter.counter += mod.add / 100;
+            }
+            break;
+          case 'comboChance':
+            if (mod.multiply !== undefined) {
+              fighter.comboChance *= mod.multiply;
+            }
+            if (mod.add !== undefined) {
+              fighter.comboChance += mod.add / 100;
+            }
+            break;
+          case 'maxCombo':
+            if (mod.multiply !== undefined) {
+              fighter.maxCombo = Math.floor(fighter.maxCombo * mod.multiply);
+            }
+            if (mod.add !== undefined) {
+              fighter.maxCombo += mod.add;
+            }
+            break;
+          case 'critChance':
+            if (mod.multiply !== undefined) {
+              fighter.critChance *= mod.multiply;
+            }
+            if (mod.add !== undefined) {
+              fighter.critChance += mod.add / 100;
+            }
+            break;
+          case 'accuracy':
+            if (mod.multiply !== undefined) {
+              fighter.accuracy *= mod.multiply;
+            }
+            if (mod.add !== undefined) {
+              fighter.accuracy += mod.add / 100;
+            }
+            break;
+        }
+      }
+    });
   }
 
   /**
@@ -116,124 +256,54 @@ export class LaBruteAuthenticEngine {
       ? thrown.damage
       : (attacker.activeWeapon?.damage || attacker.baseDamage);
 
-    let skillsMultiplier = 1;
-
     // Piledriver actif ?
     const piledriver = attacker.activeSkills?.find((sk) =>
       (typeof sk === 'string' ? sk === SkillName.hammer : sk.name === SkillName.hammer));
 
-    // Modificateurs des compétences du combattant
-    for (const modifier of SkillDamageModifiers) {
-      // Ignore si le combattant n'a pas la compétence
-      if (!attacker.skills.find((sk) =>
-        (typeof sk === 'string' ? sk === modifier.skill : sk.name === modifier.skill))) {
-        continue;
-      }
-
-      // Ignore si le modificateur est pour l'adversaire
-      if (modifier.opponent) {
-        continue;
-      }
-
-      // Ignore weaponsMaster et martialArts pour une arme lancée
-      if (thrown && (modifier.skill === SkillName.weaponsMaster || modifier.skill === SkillName.martialArts)) {
-        continue;
-      }
-
-      // Ignore martialArts si piledriver actif
-      if (piledriver && modifier.skill === SkillName.martialArts) {
-        continue;
-      }
-
-      // Modificateurs spécifiques aux armes
-      if (typeof modifier.weaponType !== 'undefined') {
-        if (modifier.weaponType === null) {
-          if (!attacker.activeWeapon || attacker.activeWeapon.name === WeaponName.mug) {
-            skillsMultiplier += modifier.percent ?? 0;
-          }
-        } else if (attacker.activeWeapon?.types?.includes(modifier.weaponType)) {
-          skillsMultiplier += modifier.percent ?? 0;
-        }
-      } else {
-        skillsMultiplier *= 1 + (modifier.percent ?? 0);
-      }
-    }
-
-    // Modificateurs de l'adversaire
-    for (const modifier of SkillDamageModifiers) {
-      // Ignore si l'adversaire n'a pas la compétence
-      if (!defender.skills.find((sk) =>
-        (typeof sk === 'string' ? sk === modifier.skill : sk.name === modifier.skill))) {
-        continue;
-      }
-
-      // Ignore si le modificateur n'est pas pour l'adversaire
-      if (!modifier.opponent) {
-        continue;
-      }
-
-      // Ignore leadSkeleton pour les armes lancées
-      if (thrown && modifier.skill === SkillName.leadSkeleton) {
-        continue;
-      }
-
-      if (typeof modifier.weaponType !== 'undefined') {
-        if (modifier.weaponType === null) {
-          if (!attacker.activeWeapon || attacker.activeWeapon.name === WeaponName.mug) {
-            skillsMultiplier += modifier.percent ?? 0;
-          }
-        } else if (attacker.activeWeapon?.types?.includes(modifier.weaponType)) {
-          skillsMultiplier += modifier.percent ?? 0;
-        }
-      } else {
-        skillsMultiplier *= 1 + (modifier.percent ?? 0);
-      }
-    }
-
-    // x2 pour fierceBrute actif
-    if (attacker.activeSkills?.find((sk) =>
-      (typeof sk === 'string' ? sk === SkillName.fierceBrute : sk.name === SkillName.fierceBrute))) {
-      skillsMultiplier *= 2;
-    }
-
-    // x4 pour piledriver
-    if (piledriver) {
-      skillsMultiplier *= 4;
-    }
-
     let damage = 0;
 
     if (thrown) {
-      damage = Math.floor(
-        (base + attacker.strength * 0.1 + attacker.agility * 0.15)
-        * (1 + this.random() * 0.5) * skillsMultiplier
-      );
+      damage = (base + attacker.strength * 0.1 + attacker.agility * 0.15)
+        * (1 + this.random() * 0.5);
     } else if (piledriver) {
-      damage = Math.floor(
-        (10 + defender.strength * 0.6)
-        * (0.8 + this.random() * 0.4) * skillsMultiplier
-      );
+      damage = (10 + defender.strength * 0.6)
+        * (0.8 + this.random() * 0.4);
     } else {
-      damage = Math.floor(
-        (base + attacker.strength * (0.2 + base * 0.05))
-        * (0.8 + this.random() * 0.4) * skillsMultiplier
-      );
+      damage = (base + attacker.strength * (0.2 + base * 0.05))
+        * (0.8 + this.random() * 0.4);
     }
+
+    // Multiplicateurs cumulés
+    let multiplier = 1;
+    multiplier *= attacker.activeWeapon ? attacker.weaponDamageMultiplier : attacker.bareHandsDamageMultiplier;
+    multiplier *= defender.incomingDamageMultiplier;
+    if (!thrown && attacker.activeWeapon?.types?.includes('melee')) {
+      multiplier *= defender.meleeWeaponMultiplier;
+    }
+    if (attacker.activeSkills?.find((sk) =>
+      (typeof sk === 'string' ? sk === SkillName.fierceBrute : sk.name === SkillName.fierceBrute))) {
+      multiplier *= 2;
+    }
+    if (piledriver) {
+      multiplier *= 4;
+    }
+
+    damage = Math.floor(damage * multiplier);
 
     // Arme endommagée ? -25%
     if (attacker.activeWeapon && attacker.damagedWeapons?.includes(attacker.activeWeapon.name)) {
       damage = Math.floor(damage * 0.75);
     }
 
-    // Coup critique (5% de base)
-    const criticalChance = 0.05;
+    // Coup critique
+    const criticalChance = attacker.critChance || 0.05;
     const criticalHit = this.random() < criticalChance;
     if (criticalHit) {
       damage = Math.floor(damage * 2);
     }
 
     // Réduction par l'armure (sauf pour les armes lancées)
-    if (!thrown) {
+    if (!thrown && defender.armor) {
       damage = Math.ceil(damage * (1 - defender.armor));
     }
 
@@ -274,50 +344,111 @@ export class LaBruteAuthenticEngine {
    */
   playFighterTurn(fighter) {
     const opponent = this.fighters.find(f => f.team !== fighter.team);
-    
+
     if (!opponent || opponent.hp <= 0) {
       return false; // Combat terminé
     }
-    
-    // Calculer les dégâts
-    const { damage, criticalHit } = this.getDamage(fighter, opponent);
-    
-    // Appliquer les dégâts
-    opponent.hp -= damage;
-    opponent.currentHp = opponent.hp;
-    
-    // Créer le step de frappe
-    const hitStep = {
-      a: StepType.Hit,
-      f: fighter.index,
-      t: opponent.index,
+
+    let comboHits = 0;
+    let continueCombo = true;
+
+    while (continueCombo && comboHits < fighter.maxCombo && opponent.hp > 0) {
+      // Vérifier la parade
+      if (this.random() < Math.max(0, opponent.block - fighter.accuracy)) {
+        this.steps.push({ a: StepType.Block, f: opponent.index, t: fighter.index });
+        // Contre après parade
+        if (this.random() < opponent.counter) {
+          this.performCounter(opponent, fighter);
+          if (fighter.hp <= 0) { return false; }
+        }
+        break;
+      }
+
+      // Vérifier l'esquive
+      if (this.random() < Math.max(0, opponent.dodge - fighter.accuracy)) {
+        this.steps.push({ a: StepType.Evade, f: opponent.index, t: fighter.index });
+        if (this.random() < opponent.counter) {
+          this.performCounter(opponent, fighter);
+          if (fighter.hp <= 0) { return false; }
+        }
+        break;
+      }
+
+      // Dégâts
+      const { damage, criticalHit } = this.getDamage(fighter, opponent);
+
+      opponent.hp -= damage;
+      opponent.currentHp = opponent.hp;
+
+      const hitStep = {
+        a: StepType.Hit,
+        f: fighter.index,
+        t: opponent.index,
+        d: damage
+      };
+
+      if (criticalHit) {
+        hitStep.c = 1;
+      }
+
+      if (fighter.activeWeapon) {
+        hitStep.w = fighter.activeWeapon.id || fighter.activeWeapon.name;
+      }
+
+      this.steps.push(hitStep);
+
+      // Mort de l'adversaire ?
+      if (opponent.hp <= 0) {
+        opponent.hp = 0;
+        opponent.currentHp = 0;
+
+        this.steps.push({ a: StepType.Death, f: opponent.index });
+
+        return false;
+      }
+
+      // Contre-attaque après avoir été touché
+      if (this.random() < opponent.counter) {
+        this.performCounter(opponent, fighter);
+        if (fighter.hp <= 0) { return false; }
+      }
+
+      comboHits++;
+      if (comboHits < fighter.maxCombo && this.random() < fighter.comboChance) {
+        continueCombo = true;
+      } else {
+        continueCombo = false;
+      }
+    }
+
+    return true; // Combat continue
+  }
+
+  /**
+   * Applique une contre-attaque
+   */
+  performCounter(defender, attacker) {
+    const { damage, criticalHit } = this.getDamage(defender, attacker);
+    attacker.hp -= damage;
+    attacker.currentHp = attacker.hp;
+
+    const counterStep = {
+      a: StepType.Counter,
+      f: defender.index,
+      t: attacker.index,
       d: damage
     };
-    
-    if (criticalHit) {
-      hitStep.c = 1;
+    if (criticalHit) { counterStep.c = 1; }
+    if (defender.activeWeapon) {
+      counterStep.w = defender.activeWeapon.id || defender.activeWeapon.name;
     }
-    
-    if (fighter.activeWeapon) {
-      hitStep.w = fighter.activeWeapon.id || fighter.activeWeapon.name;
+    this.steps.push(counterStep);
+
+    if (attacker.hp <= 0) {
+      attacker.hp = 0;
+      attacker.currentHp = 0;
+      this.steps.push({ a: StepType.Death, f: attacker.index });
     }
-    
-    this.steps.push(hitStep);
-    
-    // Vérifier la mort
-    if (opponent.hp <= 0) {
-      opponent.hp = 0;
-      opponent.currentHp = 0;
-      
-      this.steps.push({
-        a: StepType.Death,
-        f: opponent.index
-      });
-      
-      return false; // Combat terminé
-    }
-    
-    return true; // Combat continue
   }
 
   /**

--- a/src/engine/labrute-core/constants.js
+++ b/src/engine/labrute-core/constants.js
@@ -1,0 +1,195 @@
+// Constants and enums for the LaBrute engine - Converted from @labrute/core
+
+// Step types for fight animation
+export const StepType = {
+  Arrive: 'arrive',
+  End: 'end',
+  Hit: 'hit',
+  Block: 'block',
+  Evade: 'evade',
+  Move: 'move',
+  MoveBack: 'moveBack',
+  Throw: 'throw',
+  Death: 'death',
+  Counter: 'counter',
+  Equip: 'equip',
+  Trash: 'trash',
+  Steal: 'steal',
+  Disarm: 'disarm',
+  Sabotage: 'sabotage',
+  Saboteur: 'saboteur',
+  SkillActivate: 'skillActivate',
+  SkillExpire: 'skillExpire',
+  Spy: 'spy',
+  Trap: 'trap',
+  Bomb: 'bomb',
+  Hammer: 'hammer',
+  FlashFlood: 'flashFlood',
+  Haste: 'haste',
+  Vampirism: 'vampirism',
+  Heal: 'heal',
+  Regeneration: 'regeneration',
+  Eat: 'eat',
+  Treat: 'treat',
+  Leave: 'leave',
+  Resist: 'resist',
+  Survive: 'survive',
+  DropShield: 'dropShield',
+  AttemptHit: 'attemptHit',
+  Hypnotise: 'hypnotise',
+  Poison: 'poison'
+};
+
+// Weapon types
+export const WeaponType = {
+  SHARP: 'sharp',
+  HEAVY: 'heavy',
+  LONG: 'long',
+  THROWN: 'thrown',
+  BLUNT: 'blunt',
+  FAST: 'fast'
+};
+
+// Pet names
+export const PetName = {
+  dog1: 'dog1',
+  dog2: 'dog2',
+  dog3: 'dog3',
+  panther: 'panther',
+  bear: 'bear'
+};
+
+// Skill names
+export const SkillName = {
+  // Combat skills
+  hammer: 'hammer',
+  thief: 'thief',
+  fierceBrute: 'fierceBrute',
+  tragicPotion: 'tragicPotion',
+  net: 'net',
+  bomb: 'bomb',
+  cryOfTheDamned: 'cryOfTheDamned',
+  hypnosis: 'hypnosis',
+  flashFlood: 'flashFlood',
+  tamer: 'tamer',
+  vampirism: 'vampirism',
+  haste: 'haste',
+  treat: 'treat',
+  
+  // Passive skills
+  weaponsMaster: 'weaponsMaster',
+  martialArts: 'martialArts',
+  leadSkeleton: 'leadSkeleton',
+  chaining: 'chaining',
+  counterAttack: 'counterAttack',
+  bodybuilder: 'bodybuilder',
+  hideaway: 'hideaway',
+  survival: 'survival',
+  resistant: 'resistant',
+  shield: 'shield',
+  chef: 'chef',
+  backup: 'backup'
+};
+
+// Weapon names
+export const WeaponName = {
+  // Basic weapons
+  mug: 'mug',
+  knife: 'knife',
+  broadsword: 'broadsword',
+  fan: 'fan',
+  keyboard: 'keyboard',
+  leek: 'leek',
+  mace: 'mace',
+  sai: 'sai',
+  racquet: 'racquet',
+  axe: 'axe',
+  bumps: 'bumps',
+  flail: 'flail',
+  fryingPan: 'fryingPan',
+  hatchet: 'hatchet',
+  lance: 'lance',
+  trident: 'trident',
+  whip: 'whip',
+  noodleBowl: 'noodleBowl',
+  piopio: 'piopio',
+  shuriken: 'shuriken',
+  trombone: 'trombone',
+  baton: 'baton',
+  halbard: 'halbard',
+  mammothBone: 'mammothBone',
+  potatoesBasket: 'potatoesBasket',
+  stick: 'stick'
+};
+
+// Fight modifiers
+export const FightModifier = {
+  focusOpponent: 'focusOpponent',
+  alwaysUseSupers: 'alwaysUseSupers',
+  drawEveryWeapon: 'drawEveryWeapon',
+  noThrows: 'noThrows',
+  bareHandsFirstHit: 'bareHandsFirstHit',
+  startWithWeapon: 'startWithWeapon'
+};
+
+// Fight stats
+export const FightStat = {
+  HIT_SPEED: 'hitSpeed',
+  INITIATIVE: 'initiative',
+  STRENGTH: 'strength',
+  AGILITY: 'agility',
+  SPEED: 'speed',
+  HP: 'hp',
+  ACCURACY: 'accuracy',
+  BLOCK: 'block',
+  COMBO: 'combo',
+  COUNTER: 'counter',
+  CRITICAL_CHANCE: 'critical',
+  CRITICAL_DAMAGE: 'criticalDamage',
+  DEFLECT: 'deflect',
+  DISARM: 'disarm',
+  EVASION: 'evasion',
+  REVERSAL: 'reversal',
+  TEMPO: 'tempo',
+  DEXTERITY: 'dexterity'
+};
+
+// Random utility functions
+export const randomBetween = (min, max) => {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+};
+
+export const randomItem = (array) => {
+  if (!array || array.length === 0) return null;
+  return array[Math.floor(Math.random() * array.length)];
+};
+
+export const weightedRandom = (items) => {
+  if (!items || items.length === 0) return null;
+  
+  const totalWeight = items.reduce((sum, item) => sum + (item.weight || 1), 0);
+  const random = Math.random() * totalWeight;
+  
+  let currentWeight = 0;
+  for (const item of items) {
+    currentWeight += item.weight || 1;
+    if (random <= currentWeight) {
+      return item;
+    }
+  }
+  
+  return items[items.length - 1];
+};
+
+export default {
+  StepType,
+  WeaponType,
+  PetName,
+  SkillName,
+  WeaponName,
+  FightModifier,
+  FightStat,
+  randomBetween,
+  randomItem,
+  weightedRandom
+};


### PR DESCRIPTION
## Summary
- localize combat constants for client engine
- support stat modifiers from LABRUTE_SKILLS
- add block, dodge, counter and combo logic to fighter turns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad8c689a908320bf7ce6fa238fc524